### PR TITLE
Change hardcoded telegram API URL for CI mocks

### DIFF
--- a/library/src/main/java/com/pengrad/telegrambot/TelegramBotAdapter.java
+++ b/library/src/main/java/com/pengrad/telegrambot/TelegramBotAdapter.java
@@ -27,8 +27,8 @@ public class TelegramBotAdapter {
         return buildCustom(botToken, okHttpClient, API_URL);
     }
 
-    public static TelegramBot buildCustom(String botToken, OkHttpClient okHttpClient, String url) {
-        TelegramBotClient client = new TelegramBotClient(okHttpClient, gson(), apiUrl(botToken, url));
+    public static TelegramBot buildCustom(String botToken, OkHttpClient okHttpClient, String apiUrl) {
+        TelegramBotClient client = new TelegramBotClient(okHttpClient, gson(), apiUrl(botToken, apiUrl));
         FileApi fileApi = new FileApi(botToken);
         return new TelegramBot(client, fileApi);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/TelegramBotAdapter.java
+++ b/library/src/main/java/com/pengrad/telegrambot/TelegramBotAdapter.java
@@ -24,7 +24,11 @@ public class TelegramBotAdapter {
     }
 
     public static TelegramBot buildCustom(String botToken, OkHttpClient okHttpClient) {
-        TelegramBotClient client = new TelegramBotClient(okHttpClient, gson(), apiUrl(botToken));
+        return buildCustom(botToken, okHttpClient, API_URL);
+    }
+
+    public static TelegramBot buildCustom(String botToken, OkHttpClient okHttpClient, String url) {
+        TelegramBotClient client = new TelegramBotClient(okHttpClient, gson(), apiUrl(botToken, url));
         FileApi fileApi = new FileApi(botToken);
         return new TelegramBot(client, fileApi);
     }
@@ -43,7 +47,7 @@ public class TelegramBotAdapter {
         return new Gson();
     }
 
-    private static String apiUrl(String botToken) {
-        return API_URL + botToken + "/";
+    private static String apiUrl(String botToken, String uri) {
+        return uri + botToken + "/";
     }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/TelegramBotAdapter.java
+++ b/library/src/main/java/com/pengrad/telegrambot/TelegramBotAdapter.java
@@ -28,7 +28,7 @@ public class TelegramBotAdapter {
     }
 
     public static TelegramBot buildCustom(String botToken, OkHttpClient okHttpClient, String apiUrl) {
-        TelegramBotClient client = new TelegramBotClient(okHttpClient, gson(), apiUrl(botToken, apiUrl));
+        TelegramBotClient client = new TelegramBotClient(okHttpClient, gson(), apiUrl(apiUrl, botToken));
         FileApi fileApi = new FileApi(botToken);
         return new TelegramBot(client, fileApi);
     }
@@ -47,7 +47,7 @@ public class TelegramBotAdapter {
         return new Gson();
     }
 
-    private static String apiUrl(String botToken, String uri) {
-        return uri + botToken + "/";
+    private static String apiUrl(String apiUrl, String botToken) {
+        return apiUrl + botToken + "/";
     }
 }


### PR DESCRIPTION
I want to use custom mocks for CI testing phase, but URL to telegram API is [hardcoded](https://github.com/pengrad/java-telegram-bot-api/blob/master/library/src/main/java/com/pengrad/telegrambot/TelegramBotAdapter.java#L16) in the library. Can we change that by [TelegramBotAdapter::buildCustom](https://github.com/pengrad/java-telegram-bot-api/blob/master/library/src/main/java/com/pengrad/telegrambot/TelegramBotAdapter.java#L26) overloading with default value?