### PR TITLE
Make requests as a response from webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ bot.execute(request, new Callback() {
 });
 ```
 
+Request [in response to update](https://core.telegram.org/bots/faq#how-can-i-make-requests-in-response-to-updates)
+```java
+String response = request.getJSON();
+```
+
 ## Getting updates
 
 You can use **getUpdates** request, parse incoming **Webhook** request, or set listener to receive updates.  

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ bot.execute(request, new Callback() {
 
 Request [in response to update](https://core.telegram.org/bots/faq#how-can-i-make-requests-in-response-to-updates)
 ```java
-String response = request.getJSON();
+String response = request.toWebhookResponse();
 ```
 
 ## Getting updates

--- a/library/src/main/java/com/pengrad/telegrambot/request/BaseRequest.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/BaseRequest.java
@@ -60,6 +60,12 @@ abstract public class BaseRequest<T extends BaseRequest, R extends BaseResponse>
         return 0;
     }
 
+    public String getJSON(){
+        Map<String,Object> fullMap = new HashMap<>(parameters);
+        fullMap.put("method",getMethod());
+        return gson.toJson(fullMap);
+    }
+
     // Serialize model objects. Basically convert to json
     // todo move to TelegramBotClient, let it serialize everything in request time
     protected String serialize(Object o) {

--- a/library/src/main/java/com/pengrad/telegrambot/request/BaseRequest.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/BaseRequest.java
@@ -60,9 +60,9 @@ abstract public class BaseRequest<T extends BaseRequest, R extends BaseResponse>
         return 0;
     }
 
-    public String getJSON(){
+    public String toWebhookResponse() {
         Map<String,Object> fullMap = new HashMap<String,Object>(parameters);
-        fullMap.put("method",getMethod());
+        fullMap.put("method", getMethod());
         return gson.toJson(fullMap);
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/request/BaseRequest.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/BaseRequest.java
@@ -61,7 +61,7 @@ abstract public class BaseRequest<T extends BaseRequest, R extends BaseResponse>
     }
 
     public String getJSON(){
-        Map<String,Object> fullMap = new HashMap<>(parameters);
+        Map<String,Object> fullMap = new HashMap<String,Object>(parameters);
         fullMap.put("method",getMethod());
         return gson.toJson(fullMap);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/BaseRequest.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/BaseRequest.java
@@ -61,7 +61,7 @@ abstract public class BaseRequest<T extends BaseRequest, R extends BaseResponse>
     }
 
     public String toWebhookResponse() {
-        Map<String,Object> fullMap = new HashMap<String,Object>(parameters);
+        Map<String, Object> fullMap = new HashMap<String, Object>(parameters);
         fullMap.put("method", getMethod());
         return gson.toJson(fullMap);
     }


### PR DESCRIPTION
Hello there.

Official Telegram Bot API supports this: https://core.telegram.org/bots/faq#how-can-i-make-requests-in-response-to-updates . This is superfast and probably has no limits in terms of number of requests per second for one bot.

So, I think it will be good to add some kind of "getJSON" method to BaseRequest class to use this string as an answer while handling requests by webhook. I saw "serialize" method there, but you don't need serialize entire BaseRequest object, just key-value pairs of parameters + "method" field.