### PR TITLE
Sleep for sleepTimeout instead of 100 ms

### DIFF
--- a/library/src/main/java/com/pengrad/telegrambot/impl/UpdatesHandler.java
+++ b/library/src/main/java/com/pengrad/telegrambot/impl/UpdatesHandler.java
@@ -80,7 +80,7 @@ public class UpdatesHandler {
     private void sleep() {
         if (sleepTimeout <= 0L) return;
         try {
-            Thread.sleep(100);
+            Thread.sleep(sleepTimeout);
         } catch (InterruptedException ignored) {
         }
     }


### PR DESCRIPTION
The value of sleepTimeout is currently ignored. This simple patch fixes it.