### PR TITLE
Use Long for User IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 .idea
+.vs
+.settings
+library/bin/*
+
 *.iml
+*.class
 .gradle
 build
 out
@@ -8,3 +13,6 @@ target
 .DS_Store
 local.properties
 private.key
+.project
+library/.classpath
+sample/.classpath

--- a/library/src/main/java/com/pengrad/telegrambot/model/Contact.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Contact.java
@@ -12,7 +12,7 @@ public class Contact implements Serializable {
     private String phone_number;
     private String first_name;
     private String last_name;
-    private Integer user_id;
+    private Long user_id;
     private String vcard;
 
     public String phoneNumber() {
@@ -27,7 +27,7 @@ public class Contact implements Serializable {
         return last_name;
     }
 
-    public Integer userId() {
+    public Long userId() {
         return user_id;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/User.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/User.java
@@ -9,7 +9,7 @@ import java.io.Serializable;
 public class User implements Serializable {
     private final static long serialVersionUID = 0L;
 
-    private Integer id;
+    private Long id;
     private Boolean is_bot;
     private String first_name;
     private String last_name;
@@ -22,11 +22,11 @@ public class User implements Serializable {
     private User() {
     }
 
-    public User(Integer id) {
+    public User(Long id) {
         this.id = id;
     }
 
-    public Integer id() {
+    public Long id() {
         return id;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/passport/SetPassportDataErrors.java
+++ b/library/src/main/java/com/pengrad/telegrambot/passport/SetPassportDataErrors.java
@@ -9,7 +9,7 @@ import com.pengrad.telegrambot.response.BaseResponse;
  */
 public class SetPassportDataErrors extends BaseRequest<SetPassportDataErrors, BaseResponse> {
 
-    public SetPassportDataErrors(int userId, PassportElementError... errors) {
+    public SetPassportDataErrors(long userId, PassportElementError... errors) {
         super(BaseResponse.class);
         add("user_id", userId).add("errors", errors);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/AddStickerToSet.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/AddStickerToSet.java
@@ -9,15 +9,15 @@ import com.pengrad.telegrambot.response.BaseResponse;
  */
 public class AddStickerToSet extends AbstractUploadRequest<AddStickerToSet, BaseResponse> {
 
-    public static AddStickerToSet tgsSticker(Integer userId, String name, String emojis, Object tgsSticker) {
+    public static AddStickerToSet tgsSticker(Long userId, String name, String emojis, Object tgsSticker) {
         return new AddStickerToSet(userId, name, emojis, "tgs_sticker", tgsSticker);
     }
 
-    public AddStickerToSet(Integer userId, String name, Object pngSticker, String emojis) {
+    public AddStickerToSet(Long userId, String name, Object pngSticker, String emojis) {
         this(userId, name, emojis, "png_sticker", pngSticker);
     }
 
-    private AddStickerToSet(Integer userId, String name, String emojis, String stickerParam, Object sticker) {
+    private AddStickerToSet(Long userId, String name, String emojis, String stickerParam, Object sticker) {
         super(BaseResponse.class, stickerParam, sticker);
         add("user_id", userId);
         add("name", name);

--- a/library/src/main/java/com/pengrad/telegrambot/request/CreateNewStickerSet.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/CreateNewStickerSet.java
@@ -9,15 +9,15 @@ import com.pengrad.telegrambot.response.BaseResponse;
  */
 public class CreateNewStickerSet extends AbstractUploadRequest<CreateNewStickerSet, BaseResponse> {
 
-    public static CreateNewStickerSet tgsSticker(Integer userId, String name, String title, String emojis, Object tgsSticker) {
+    public static CreateNewStickerSet tgsSticker(Long userId, String name, String title, String emojis, Object tgsSticker) {
         return new CreateNewStickerSet(userId, name, title, emojis, "tgs_sticker", tgsSticker);
     }
 
-    public CreateNewStickerSet(Integer userId, String name, String title, Object pngSticker, String emojis) {
+    public CreateNewStickerSet(Long userId, String name, String title, Object pngSticker, String emojis) {
         this(userId, name, title, emojis, "png_sticker", pngSticker);
     }
 
-    private CreateNewStickerSet(Integer userId, String name, String title, String emojis, String stickerParam, Object sticker) {
+    private CreateNewStickerSet(Long userId, String name, String title, String emojis, String stickerParam, Object sticker) {
         super(BaseResponse.class, stickerParam, sticker);
         add("user_id", userId);
         add("name", name);

--- a/library/src/main/java/com/pengrad/telegrambot/request/GetChatMember.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/GetChatMember.java
@@ -8,7 +8,7 @@ import com.pengrad.telegrambot.response.GetChatMemberResponse;
  */
 public class GetChatMember extends BaseRequest<GetChatMember, GetChatMemberResponse> {
 
-    public GetChatMember(Object chatId, int userId) {
+    public GetChatMember(Object chatId, long userId) {
         super(GetChatMemberResponse.class);
         add("chat_id", chatId).add("user_id", userId);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/GetGameHighScores.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/GetGameHighScores.java
@@ -8,12 +8,12 @@ import com.pengrad.telegrambot.response.GetGameHighScoresResponse;
  */
 public class GetGameHighScores extends BaseRequest<GetGameHighScores, GetGameHighScoresResponse> {
 
-    public GetGameHighScores(int userId, Object chatId, int messageId) {
+    public GetGameHighScores(long userId, Object chatId, int messageId) {
         super(GetGameHighScoresResponse.class);
         add("user_id", userId).add("chat_id", chatId).add("message_id", messageId);
     }
 
-    public GetGameHighScores(int userId, String inlineMessageId) {
+    public GetGameHighScores(long userId, String inlineMessageId) {
         super(GetGameHighScoresResponse.class);
         add("user_id", userId).add("inline_message_id", inlineMessageId);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/GetUserProfilePhotos.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/GetUserProfilePhotos.java
@@ -8,7 +8,7 @@ import com.pengrad.telegrambot.response.GetUserProfilePhotosResponse;
  */
 public class GetUserProfilePhotos extends BaseRequest<GetUserProfilePhotos, GetUserProfilePhotosResponse> {
 
-    public GetUserProfilePhotos(int userId) {
+    public GetUserProfilePhotos(long userId) {
         super(GetUserProfilePhotosResponse.class);
         add("user_id", userId);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/KickChatMember.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/KickChatMember.java
@@ -8,7 +8,7 @@ import com.pengrad.telegrambot.response.BaseResponse;
  */
 public class KickChatMember extends BaseRequest<KickChatMember, BaseResponse> {
 
-    public KickChatMember(Object chatId, int userId) {
+    public KickChatMember(Object chatId, long userId) {
         super(BaseResponse.class);
         add("chat_id", chatId).add("user_id", userId);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/PromoteChatMember.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/PromoteChatMember.java
@@ -8,7 +8,7 @@ import com.pengrad.telegrambot.response.BaseResponse;
  */
 public class PromoteChatMember extends BaseRequest<PromoteChatMember, BaseResponse> {
 
-    public PromoteChatMember(Object chatId, int userId) {
+    public PromoteChatMember(Object chatId, long userId) {
         super(BaseResponse.class);
         add("chat_id", chatId).add("user_id", userId);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/RestrictChatMember.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/RestrictChatMember.java
@@ -9,12 +9,12 @@ import com.pengrad.telegrambot.response.BaseResponse;
  */
 public class RestrictChatMember extends BaseRequest<RestrictChatMember, BaseResponse> {
 
-    public RestrictChatMember(Object chatId, int userId) {
+    public RestrictChatMember(Object chatId, long userId) {
         super(BaseResponse.class);
         add("chat_id", chatId).add("user_id", userId);
     }
 
-    public RestrictChatMember(Object chatId, int userId, ChatPermissions permissions) {
+    public RestrictChatMember(Object chatId, long userId, ChatPermissions permissions) {
         super(BaseResponse.class);
         add("chat_id", chatId).add("user_id", userId).add("permissions", permissions);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/SendInvoice.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SendInvoice.java
@@ -8,7 +8,7 @@ import com.pengrad.telegrambot.model.request.LabeledPrice;
  */
 public class SendInvoice extends AbstractSendRequest<SendInvoice> {
 
-    public SendInvoice(Integer chatId, String title, String description, String payload, String providerToken,
+    public SendInvoice(Long chatId, String title, String description, String payload, String providerToken,
                        String startParameter, String currency, LabeledPrice... prices) {
         super(chatId);
         add("title", title).add("description", description).add("payload", payload).add("provider_token", providerToken)

--- a/library/src/main/java/com/pengrad/telegrambot/request/SetChatAdministratorCustomTitle.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SetChatAdministratorCustomTitle.java
@@ -8,7 +8,7 @@ import com.pengrad.telegrambot.response.BaseResponse;
  */
 public class SetChatAdministratorCustomTitle extends BaseRequest<SetChatAdministratorCustomTitle, BaseResponse> {
 
-    public SetChatAdministratorCustomTitle(Object chatId, int userId, String customTitle) {
+    public SetChatAdministratorCustomTitle(Object chatId, long userId, String customTitle) {
         super(BaseResponse.class);
         add("chat_id", chatId).add("user_id", userId).add("custom_title", customTitle);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/SetGameScore.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SetGameScore.java
@@ -9,12 +9,12 @@ import com.pengrad.telegrambot.response.SendResponse;
  */
 public class SetGameScore extends BaseRequest<SetGameScore, BaseResponse> {
 
-    public SetGameScore(int userId, int score, Object chatId, int messageId) {
+    public SetGameScore(long userId, int score, Object chatId, int messageId) {
         super(SendResponse.class);
         add("user_id", userId).add("score", score).add("chat_id", chatId).add("message_id", messageId);
     }
 
-    public SetGameScore(int userId, int score, String inlineMessageId) {
+    public SetGameScore(long userId, int score, String inlineMessageId) {
         super(BaseResponse.class);
         add("user_id", userId).add("score", score).add("inline_message_id", inlineMessageId);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/SetStickerSetThumb.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SetStickerSetThumb.java
@@ -8,13 +8,13 @@ import com.pengrad.telegrambot.response.BaseResponse;
  */
 public class SetStickerSetThumb extends AbstractUploadRequest<AddStickerToSet, BaseResponse> {
 
-    public SetStickerSetThumb(String name, Integer userId, Object thumb) {
+    public SetStickerSetThumb(String name, Long userId, Object thumb) {
         super(BaseResponse.class, "thumb", thumb);
         add("name", name);
         add("user_id", userId);
     }
 
-    public SetStickerSetThumb(String name, Integer userId) {
+    public SetStickerSetThumb(String name, Long userId) {
         super(BaseResponse.class, "name", name);
         add("user_id", userId);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/UnbanChatMember.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/UnbanChatMember.java
@@ -8,7 +8,7 @@ import com.pengrad.telegrambot.response.BaseResponse;
  */
 public class UnbanChatMember extends BaseRequest<UnbanChatMember, BaseResponse> {
 
-    public UnbanChatMember(Object chatId, int userId) {
+    public UnbanChatMember(Object chatId, long userId) {
         super(BaseResponse.class);
         add("chat_id", chatId).add("user_id", userId);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/UploadStickerFile.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/UploadStickerFile.java
@@ -8,7 +8,7 @@ import com.pengrad.telegrambot.response.GetFileResponse;
  */
 public class UploadStickerFile extends AbstractUploadRequest<UploadStickerFile, GetFileResponse> {
 
-    public UploadStickerFile(Integer userId, Object pngSticker) {
+    public UploadStickerFile(Long userId, Object pngSticker) {
         super(GetFileResponse.class, "png_sticker", pngSticker);
         add("user_id", userId);
     }

--- a/library/src/test/java/com/pengrad/telegrambot/PaymentsTest.java
+++ b/library/src/test/java/com/pengrad/telegrambot/PaymentsTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.*;
 public class PaymentsTest {
 
     static TelegramBot bot = TelegramBotTest.bot;
-    static Integer chatId = TelegramBotTest.chatId;
+    static Long chatId = TelegramBotTest.chatId;
 
     String testShippingQuery = getProp("TEST_SHIP_QUERY");
     String testPreCheckoutQuery = getProp("TEST_PRECHECKOUT_QUERY");

--- a/library/src/test/java/com/pengrad/telegrambot/TelegramBotTest.java
+++ b/library/src/test/java/com/pengrad/telegrambot/TelegramBotTest.java
@@ -118,7 +118,7 @@ public class TelegramBotTest {
 
         String chat = getProp("CHAT_ID");
         String group = getProp("GROUP_ID");
-        chatId = Integer.parseInt(chat);
+        chatId = Long.parseLong(chat);
         groupId = Long.parseLong(group);
 
         privateKey = getProp("PRIVATE_KEY");
@@ -145,14 +145,14 @@ public class TelegramBotTest {
     }
 
     static TelegramBot bot = createTestBot();
-    static Integer chatId;
+    static Long chatId;
     static Long groupId;
     Integer forwardMessageId = 33263;
     Integer forwardMessageIdUser = 23714;
     String stickerId = "BQADAgAD4AAD9HsZAAGVRXVaYXiJVAI";
     String channelName = "@bottest";
     Long channelId = -1001002720332L;
-    Integer memberBot = 215003245;
+    Long memberBot = 215003245L;
     Long localGroup = -1001431704825L;
     static String privateKey;
     static String testPassportData;


### PR DESCRIPTION
As per Telegram BOT API changelogs:

> After one of the upcoming Bot API updates, user identifiers will become bigger than 2^31 - 1 and it will be no longer possible to store them in a signed 32-bit integer type. User identifiers will have up to 52 significant bits, so a 64-bit integer or double-precision float type would still be safe for storing them. Please make sure that your code can correctly handle such user identifiers.

Note: I was not able to run tests on the provided code but the changes are pretty simple and should work straight away