### PR TITLE
Allow instantiate TelegramBot with `builder` parameter

### DIFF
--- a/library/src/main/java/com/pengrad/telegrambot/TelegramBot.java
+++ b/library/src/main/java/com/pengrad/telegrambot/TelegramBot.java
@@ -32,7 +32,7 @@ public class TelegramBot {
         this(new Builder(botToken));
     }
 
-    TelegramBot(Builder builder) {
+    public TelegramBot(Builder builder) {
         this.api = builder.api;
         this.fileApi = builder.fileApi;
         this.updatesHandler = builder.updatesHandler;


### PR DESCRIPTION
Currently there is no way to set builder parameters like `updatesHandler` cause when we instantiate `TelegramBot` it creates Builder in class's constructor.
I added ability to create TelegramBot with builder parameter, so we can do something like that:

TelegramBot.Builder builder = new TelegramBot.Builder(token);
builder.updateListenerSleep(500L);
TelegramBot telegramBot = new TelegramBot(builder);