### PR TITLE
BOT Api v6.0

### DIFF
--- a/library/src/main/java/com/pengrad/telegrambot/model/ChatAdministratorRights.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/ChatAdministratorRights.java
@@ -1,0 +1,112 @@
+package com.pengrad.telegrambot.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class ChatAdministratorRights implements Serializable {
+
+    private final static long serialVersionUID = 0L;
+    
+    private Boolean is_anonymous;
+    private Boolean can_manage_chat;
+    private Boolean can_delete_messages;
+    private Boolean can_manage_video_chats;
+    private Boolean can_restrict_members;
+    private Boolean can_promote_members;
+    private Boolean can_change_info;
+    private Boolean can_invite_users;
+    private Boolean can_post_messages;
+    private Boolean can_edit_messages;
+    private Boolean can_pin_messages;
+
+    public Boolean isAnonymous() {
+        return is_anonymous;
+    }
+
+    public Boolean canManageChat() {
+        return can_manage_chat;
+    }
+
+    public Boolean canDeleteMessages() {
+        return can_delete_messages;
+    }
+
+    public Boolean canManageVideoChats() {
+        return can_manage_video_chats;
+    }
+
+    public Boolean canRestrictMembers() {
+        return can_restrict_members;
+    }
+
+    public Boolean canPromoteMembers() {
+        return can_promote_members;
+    }
+
+    public Boolean canChangeInfo() {
+        return can_change_info;
+    }
+
+    public Boolean canInviteUsers() {
+        return can_invite_users;
+    }
+
+    public Boolean canPostMessages() {
+        return can_post_messages;
+    }
+
+    public Boolean canEditMessages() {
+        return can_edit_messages;
+    }
+
+    public Boolean canPinMessages() {
+        return can_pin_messages;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ChatAdministratorRights that = (ChatAdministratorRights) o;
+        return is_anonymous == that.is_anonymous &&
+                can_manage_chat == that.can_manage_chat &&
+                can_delete_messages == that.can_delete_messages &&
+                can_manage_video_chats == that.can_manage_video_chats &&
+                can_restrict_members == that.can_restrict_members &&
+                can_promote_members == that.can_promote_members &&
+                can_change_info == that.can_change_info &&
+                can_invite_users == that.can_invite_users &&
+                can_post_messages == that.can_post_messages &&
+                can_edit_messages == that.can_edit_messages &&
+                can_pin_messages == that.can_pin_messages;
+                
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(is_anonymous, can_manage_chat, can_delete_messages, can_manage_video_chats, can_restrict_members, can_promote_members, can_change_info, can_invite_users, can_post_messages, can_edit_messages, can_pin_messages);
+    }
+
+    @Override
+    public String toString() {
+        return "ChatAdministratorRights{" +
+                "is_anonymous=" + is_anonymous +
+                ", can_manage_chat=" + can_manage_chat +
+                ", can_delete_messages='" + can_delete_messages + '\'' +
+                ", can_manage_video_chats=" + can_manage_video_chats +
+                ", can_restrict_members=" + can_restrict_members +
+                ", can_promote_members=" + can_promote_members +
+                ", can_change_info=" + can_change_info +
+                ", can_invite_users=" + can_invite_users +
+                ", can_post_messages=" + can_post_messages +
+                ", can_edit_messages=" + can_edit_messages +
+                ", can_pin_messages=" + can_pin_messages +
+                '}';
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/ChatMember.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/ChatMember.java
@@ -24,8 +24,8 @@ public class ChatMember implements Serializable {
     private Boolean can_manage_chat;
     private Boolean can_post_messages;
     private Boolean can_edit_messages;
-    private Boolean can_delete_messages;
-    private Boolean can_manage_voice_chats;
+    private Boolean can_delete_messages;    
+    private Boolean can_manage_video_chats;
     private Boolean can_restrict_members;
     private Boolean can_promote_members;
     private Boolean can_change_info;
@@ -78,8 +78,15 @@ public class ChatMember implements Serializable {
         return can_delete_messages;
     }
 
+    /**
+     *  @Deprecated Use canManageVideoChats() instead
+     */   
     public Boolean canManageVoiceChats() {
-        return can_manage_voice_chats;
+        return can_manage_video_chats;
+    }
+
+    public Boolean canManageVideoChats() {
+        return can_manage_video_chats;
     }
 
     public Boolean canRestrictMembers() {
@@ -141,7 +148,7 @@ public class ChatMember implements Serializable {
                 Objects.equals(can_post_messages, that.can_post_messages) &&
                 Objects.equals(can_edit_messages, that.can_edit_messages) &&
                 Objects.equals(can_delete_messages, that.can_delete_messages) &&
-                Objects.equals(can_manage_voice_chats, that.can_manage_voice_chats) &&
+                Objects.equals(can_manage_video_chats, that.can_manage_video_chats) &&
                 Objects.equals(can_restrict_members, that.can_restrict_members) &&
                 Objects.equals(can_promote_members, that.can_promote_members) &&
                 Objects.equals(can_change_info, that.can_change_info) &&
@@ -157,7 +164,7 @@ public class ChatMember implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(user, status, custom_title, is_anonymous, until_date, can_be_edited, can_manage_chat, can_post_messages, can_edit_messages, can_delete_messages, can_manage_voice_chats, can_restrict_members, can_promote_members, can_change_info, can_invite_users, can_pin_messages, is_member, can_send_messages, can_send_media_messages, can_send_polls, can_send_other_messages, can_add_web_page_previews);
+        return Objects.hash(user, status, custom_title, is_anonymous, until_date, can_be_edited, can_manage_chat, can_post_messages, can_edit_messages, can_delete_messages, can_manage_video_chats, can_restrict_members, can_promote_members, can_change_info, can_invite_users, can_pin_messages, is_member, can_send_messages, can_send_media_messages, can_send_polls, can_send_other_messages, can_add_web_page_previews);
     }
 
     @Override
@@ -173,7 +180,7 @@ public class ChatMember implements Serializable {
                 ", can_post_messages=" + can_post_messages +
                 ", can_edit_messages=" + can_edit_messages +
                 ", can_delete_messages=" + can_delete_messages +
-                ", can_manage_voice_chats=" + can_manage_voice_chats +
+                ", can_manage_video_chats=" + can_manage_video_chats +
                 ", can_restrict_members=" + can_restrict_members +
                 ", can_promote_members=" + can_promote_members +
                 ", can_change_info=" + can_change_info +

--- a/library/src/main/java/com/pengrad/telegrambot/model/MenuButton.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/MenuButton.java
@@ -1,0 +1,18 @@
+package com.pengrad.telegrambot.model;
+
+import java.io.Serializable;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class MenuButton<T extends MenuButton<T>> implements Serializable {
+   
+    private final static long serialVersionUID = 0L;
+    
+    private final String type;
+
+    public MenuButton(String type) {
+        this.type = type;
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/MenuButtonCommands.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/MenuButtonCommands.java
@@ -1,0 +1,16 @@
+package com.pengrad.telegrambot.model;
+
+import java.io.Serializable;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class MenuButtonCommands extends MenuButton<MenuButtonCommands> implements Serializable {
+    
+    private final static long serialVersionUID = 0L;
+
+    public MenuButtonCommands() {
+        super("commands");
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/MenuButtonDefault.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/MenuButtonDefault.java
@@ -1,0 +1,16 @@
+package com.pengrad.telegrambot.model;
+
+import java.io.Serializable;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class MenuButtonDefault extends MenuButton<MenuButtonDefault> implements Serializable {
+ 
+    private final static long serialVersionUID = 0L;
+
+    public MenuButtonDefault() {
+        super("default");
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/MenuButtonWebApp.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/MenuButtonWebApp.java
@@ -1,0 +1,22 @@
+package com.pengrad.telegrambot.model;
+
+import java.io.Serializable;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class MenuButtonWebApp extends MenuButton<MenuButtonWebApp> implements Serializable {
+    
+    private final static long serialVersionUID = 0L;
+
+    private String text;
+    private WebAppInfo web_app_info;
+
+    public MenuButtonWebApp(String text, WebAppInfo webAppInfo) {
+        super("web_app");
+        this.text = text;
+        this.web_app_info = webAppInfo;
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/Message.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Message.java
@@ -72,6 +72,7 @@ public class Message implements Serializable {
     private VoiceChatParticipantsInvited voice_chat_participants_invited;
     private VoiceChatScheduled voice_chat_scheduled;
     private InlineKeyboardMarkup reply_markup;
+    private WebAppData web_app_data;
 
     public Integer messageId() {
         return message_id;
@@ -305,6 +306,10 @@ public class Message implements Serializable {
         return reply_markup;
     }
 
+    public WebAppData webAppData() {
+        return web_app_data;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -367,7 +372,8 @@ public class Message implements Serializable {
                 Objects.equals(voice_chat_ended, message.voice_chat_ended) &&
                 Objects.equals(voice_chat_participants_invited, message.voice_chat_participants_invited) &&
                 Objects.equals(voice_chat_scheduled, message.voice_chat_scheduled) &&
-                Objects.equals(reply_markup, message.reply_markup);
+                Objects.equals(reply_markup, message.reply_markup) &&
+                Objects.equals(web_app_data, message.web_app_data);
     }
 
     @Override
@@ -436,6 +442,7 @@ public class Message implements Serializable {
                 ", voice_chat_participants_invited=" + voice_chat_participants_invited +
                 ", voice_chat_scheduled=" + voice_chat_scheduled +
                 ", reply_markup=" + reply_markup +
+                ", web_app_data=" + web_app_data +
                 '}';
     }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/model/Message.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Message.java
@@ -67,10 +67,10 @@ public class Message implements Serializable {
     private String connected_website;
     private PassportData passport_data;
     private ProximityAlertTriggered proximity_alert_triggered;
-    private VoiceChatStarted voice_chat_started;
-    private VoiceChatEnded voice_chat_ended;
-    private VoiceChatParticipantsInvited voice_chat_participants_invited;
-    private VoiceChatScheduled voice_chat_scheduled;
+    private VideoChatStarted video_chat_started;
+    private VideoChatEnded video_chat_ended;
+    private VideoChatParticipantsInvited video_chat_participants_invited;
+    private VideoChatScheduled video_chat_scheduled;
     private InlineKeyboardMarkup reply_markup;
     private WebAppData web_app_data;
 
@@ -286,20 +286,20 @@ public class Message implements Serializable {
         return proximity_alert_triggered;
     }
 
-    public VoiceChatStarted voiceChatStarted() {
-        return voice_chat_started;
+    public VideoChatStarted videoChatStarted() {
+        return video_chat_started;
     }
 
-    public VoiceChatEnded voiceChatEnded() {
-        return voice_chat_ended;
+    public VideoChatEnded videoChatEnded() {
+        return video_chat_ended;
     }
 
-    public VoiceChatParticipantsInvited voiceChatParticipantsInvited() {
-        return voice_chat_participants_invited;
+    public VideoChatParticipantsInvited videoChatParticipantsInvited() {
+        return video_chat_participants_invited;
     }
 
-    public VoiceChatScheduled voiceChatScheduled() {
-        return voice_chat_scheduled;
+    public VideoChatScheduled videoChatScheduled() {
+        return video_chat_scheduled;
     }
 
     public InlineKeyboardMarkup replyMarkup() {
@@ -368,10 +368,10 @@ public class Message implements Serializable {
                 Objects.equals(connected_website, message.connected_website) &&
                 Objects.equals(passport_data, message.passport_data) &&
                 Objects.equals(proximity_alert_triggered, message.proximity_alert_triggered) &&
-                Objects.equals(voice_chat_started, message.voice_chat_started) &&
-                Objects.equals(voice_chat_ended, message.voice_chat_ended) &&
-                Objects.equals(voice_chat_participants_invited, message.voice_chat_participants_invited) &&
-                Objects.equals(voice_chat_scheduled, message.voice_chat_scheduled) &&
+                Objects.equals(video_chat_started, message.video_chat_started) &&
+                Objects.equals(video_chat_ended, message.video_chat_ended) &&
+                Objects.equals(video_chat_participants_invited, message.video_chat_participants_invited) &&
+                Objects.equals(video_chat_scheduled, message.video_chat_scheduled) &&
                 Objects.equals(reply_markup, message.reply_markup) &&
                 Objects.equals(web_app_data, message.web_app_data);
     }
@@ -437,10 +437,10 @@ public class Message implements Serializable {
                 ", connected_website='" + connected_website + '\'' +
                 ", passport_data=" + passport_data +
                 ", proximity_alert_triggered=" + proximity_alert_triggered +
-                ", voice_chat_started=" + voice_chat_started +
-                ", voice_chat_ended=" + voice_chat_ended +
-                ", voice_chat_participants_invited=" + voice_chat_participants_invited +
-                ", voice_chat_scheduled=" + voice_chat_scheduled +
+                ", video_chat_started=" + video_chat_started +
+                ", video_chat_ended=" + video_chat_ended +
+                ", video_chat_participants_invited=" + video_chat_participants_invited +
+                ", video_chat_scheduled=" + video_chat_scheduled +
                 ", reply_markup=" + reply_markup +
                 ", web_app_data=" + web_app_data +
                 '}';

--- a/library/src/main/java/com/pengrad/telegrambot/model/SentWebAppMessage.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/SentWebAppMessage.java
@@ -1,0 +1,48 @@
+package com.pengrad.telegrambot.model;
+
+import java.io.Serializable;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class SentWebAppMessage implements Serializable {
+    
+    private final static long serialVersionUID = 0L;
+
+    private String inline_message_id;
+
+    public SentWebAppMessage() {
+        this.inline_message_id = null;
+    }
+
+    public SentWebAppMessage(String inlineMessageId) {
+        this.inline_message_id = inlineMessageId;
+    }
+
+    public String inlineMessageId() {
+        return inline_message_id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SentWebAppMessage sentWebAppMessage = (SentWebAppMessage) o;
+
+        return sentWebAppMessage != null ? inline_message_id.equals(sentWebAppMessage.inline_message_id) : sentWebAppMessage.inline_message_id == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return inline_message_id != null ? inline_message_id.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "SentWebAppMessage{" +
+                "inline_message_id='" + inline_message_id + '\'' +
+                '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/VideoChatEnded.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/VideoChatEnded.java
@@ -1,39 +1,38 @@
 package com.pengrad.telegrambot.model;
 
 import java.io.Serializable;
-import java.util.List;
 import java.util.Objects;
 
 /**
  * Stas Parshin
  * 10 March 2021
  */
-public class VoiceChatParticipantsInvited implements Serializable {
+public class VideoChatEnded implements Serializable {
     private final static long serialVersionUID = 0L;
 
-    private List<User> users;
+    private Integer duration;
 
-    public List<User> users() {
-        return users;
+    public Integer duration() {
+        return duration;
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        VoiceChatParticipantsInvited that = (VoiceChatParticipantsInvited) o;
-        return Objects.equals(users, that.users);
+        VideoChatEnded that = (VideoChatEnded) o;
+        return Objects.equals(duration, that.duration);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(users);
+        return Objects.hash(duration);
     }
 
     @Override
     public String toString() {
-        return "VoiceChatParticipantsInvited{" +
-                "users=" + users +
+        return "VideoChatEnded{" +
+                "duration=" + duration +
                 '}';
     }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/model/VideoChatParticipantsInvited.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/VideoChatParticipantsInvited.java
@@ -1,38 +1,39 @@
 package com.pengrad.telegrambot.model;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 
 /**
  * Stas Parshin
  * 10 March 2021
  */
-public class VoiceChatEnded implements Serializable {
+public class VideoChatParticipantsInvited implements Serializable {
     private final static long serialVersionUID = 0L;
 
-    private Integer duration;
+    private List<User> users;
 
-    public Integer duration() {
-        return duration;
+    public List<User> users() {
+        return users;
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        VoiceChatEnded that = (VoiceChatEnded) o;
-        return Objects.equals(duration, that.duration);
+        VideoChatParticipantsInvited that = (VideoChatParticipantsInvited) o;
+        return Objects.equals(users, that.users);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(duration);
+        return Objects.hash(users);
     }
 
     @Override
     public String toString() {
-        return "VoiceChatEnded{" +
-                "duration=" + duration +
+        return "VideoChatParticipantsInvited{" +
+                "users=" + users +
                 '}';
     }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/model/VideoChatScheduled.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/VideoChatScheduled.java
@@ -3,7 +3,7 @@ package com.pengrad.telegrambot.model;
 import java.io.Serializable;
 import java.util.Objects;
 
-public class VoiceChatScheduled implements Serializable {
+public class VideoChatScheduled implements Serializable {
 
     private final static long serialVersionUID = 0L;
 
@@ -17,7 +17,7 @@ public class VoiceChatScheduled implements Serializable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        VoiceChatScheduled that = (VoiceChatScheduled) o;
+        VideoChatScheduled that = (VideoChatScheduled) o;
         return Objects.equals(start_date, that.start_date);
     }
 
@@ -28,7 +28,7 @@ public class VoiceChatScheduled implements Serializable {
 
     @Override
     public String toString() {
-        return "VoiceChatScheduled{" +
+        return "VideoChatScheduled{" +
                 "start_date=" + start_date +
                 '}';
     }

--- a/library/src/main/java/com/pengrad/telegrambot/model/VideoChatStarted.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/VideoChatStarted.java
@@ -6,7 +6,7 @@ import java.io.Serializable;
  * Stas Parshin
  * 10 March 2021
  */
-public class VoiceChatStarted implements Serializable {
+public class VideoChatStarted implements Serializable {
     private final static long serialVersionUID = 0L;
 
     @Override

--- a/library/src/main/java/com/pengrad/telegrambot/model/WebAppData.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/WebAppData.java
@@ -1,0 +1,48 @@
+package com.pengrad.telegrambot.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class WebAppData implements Serializable {
+    
+    private final static long serialVersionUID = 0L;
+
+    private String data;
+
+    private String button_text;
+
+    public String data() {
+        return data;
+    }
+
+    public String buttonText() {
+        return button_text;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WebAppData that = (WebAppData) o;
+        return Objects.equals(data, that.data) &&
+                Objects.equals(button_text, that.button_text);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, button_text);
+    }
+
+    @Override
+    public String toString() {
+        return "WebAppData{" +
+                "data=" + data +
+                ", button_text=" + button_text +
+                '}';
+    }
+    
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/WebAppInfo.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/WebAppInfo.java
@@ -1,0 +1,45 @@
+package com.pengrad.telegrambot.model;
+
+import java.io.Serializable;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class WebAppInfo implements Serializable {
+
+    private final static long serialVersionUID = 0L;
+
+    private String url;
+
+    public WebAppInfo(String url) {
+        this.url = url;
+    }
+
+    public String url() {
+        return url;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        WebAppInfo webAppInfo = (WebAppInfo) o;
+
+        return url != null ? url.equals(webAppInfo.url) : webAppInfo.url == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return url != null ? url.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "WebAppInfo{" +
+                "url='" + url + '\'' +
+                '}';
+    }
+    
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/WebhookInfo.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/WebhookInfo.java
@@ -17,6 +17,7 @@ public class WebhookInfo implements Serializable {
     private String ip_address;
     private Integer last_error_date;
     private String last_error_message;
+    private Integer last_synchronization_error_date;
     private Integer max_connections;
     private String[] allowed_updates;
 
@@ -44,6 +45,10 @@ public class WebhookInfo implements Serializable {
         return last_error_message;
     }
 
+    public Integer lastSynchronizationErrorDate() {
+        return last_synchronization_error_date;
+    }
+
     public Integer maxConnections() {
         return max_connections;
     }
@@ -63,13 +68,14 @@ public class WebhookInfo implements Serializable {
                 Objects.equals(ip_address, that.ip_address) &&
                 Objects.equals(last_error_date, that.last_error_date) &&
                 Objects.equals(last_error_message, that.last_error_message) &&
+                Objects.equals(last_synchronization_error_date, that.last_synchronization_error_date) &&
                 Objects.equals(max_connections, that.max_connections) &&
                 Arrays.equals(allowed_updates, that.allowed_updates);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(url, has_custom_certificate, pending_update_count, ip_address, last_error_date, last_error_message, max_connections);
+        int result = Objects.hash(url, has_custom_certificate, pending_update_count, ip_address, last_error_date, last_error_message, last_synchronization_error_date, max_connections);
         result = 31 * result + Arrays.hashCode(allowed_updates);
         return result;
     }
@@ -83,6 +89,7 @@ public class WebhookInfo implements Serializable {
                 ", ip_address='" + ip_address + '\'' +
                 ", last_error_date=" + last_error_date +
                 ", last_error_message='" + last_error_message + '\'' +
+                ", last_synchronization_error_date=" + last_synchronization_error_date +
                 ", max_connections=" + max_connections +
                 ", allowed_updates=" + Arrays.toString(allowed_updates) +
                 '}';

--- a/library/src/main/java/com/pengrad/telegrambot/model/request/InlineKeyboardButton.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/request/InlineKeyboardButton.java
@@ -3,6 +3,8 @@ package com.pengrad.telegrambot.model.request;
 import java.io.Serializable;
 import java.util.Objects;
 
+import com.pengrad.telegrambot.model.WebAppInfo;
+
 /**
  * Stas Parshin
  * 06 May 2016
@@ -18,6 +20,7 @@ public class InlineKeyboardButton implements Serializable {
     private String switch_inline_query_current_chat;
     private CallbackGame callback_game;
     private Boolean pay;
+    private WebAppInfo web_app_info;
 
     private InlineKeyboardButton() {
     }
@@ -63,6 +66,11 @@ public class InlineKeyboardButton implements Serializable {
         return this;
     }
 
+    public InlineKeyboardButton webAppInfo(WebAppInfo webAppInfo) {
+        this.web_app_info = webAppInfo;
+        return this;
+    } 
+
     public String text() {
         return text;
     }
@@ -91,6 +99,10 @@ public class InlineKeyboardButton implements Serializable {
         return pay != null ? pay : false;
     }
 
+    public WebAppInfo webAppInfo() {
+        return web_app_info;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -103,12 +115,13 @@ public class InlineKeyboardButton implements Serializable {
                 Objects.equals(switch_inline_query, that.switch_inline_query) &&
                 Objects.equals(switch_inline_query_current_chat, that.switch_inline_query_current_chat) &&
                 Objects.equals(callback_game, that.callback_game) &&
-                Objects.equals(pay, that.pay);
+                Objects.equals(pay, that.pay) &&
+                Objects.equals(web_app_info, that.web_app_info);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(text, url, login_url, callback_data, switch_inline_query, switch_inline_query_current_chat, callback_game, pay);
+        return Objects.hash(text, url, login_url, callback_data, switch_inline_query, switch_inline_query_current_chat, callback_game, pay, web_app_info);
     }
 
     @Override
@@ -122,6 +135,7 @@ public class InlineKeyboardButton implements Serializable {
                 ", switch_inline_query_current_chat='" + switch_inline_query_current_chat + '\'' +
                 ", callback_game=" + callback_game +
                 ", pay=" + pay +
+                ", web_app_info=" + (web_app_info!=null?web_app_info.toString():null) +
                 '}';
     }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/model/request/InlineKeyboardButton.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/request/InlineKeyboardButton.java
@@ -135,7 +135,7 @@ public class InlineKeyboardButton implements Serializable {
                 ", switch_inline_query_current_chat='" + switch_inline_query_current_chat + '\'' +
                 ", callback_game=" + callback_game +
                 ", pay=" + pay +
-                ", web_app_info=" + (web_app_info!=null?web_app_info.toString():null) +
+                ", web_app_info=" + web_app_info +
                 '}';
     }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/model/request/KeyboardButton.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/request/KeyboardButton.java
@@ -2,6 +2,8 @@ package com.pengrad.telegrambot.model.request;
 
 import java.io.Serializable;
 
+import com.pengrad.telegrambot.model.WebAppInfo;
+
 /**
  * Stas Parshin
  * 06 May 2016
@@ -13,6 +15,7 @@ public class KeyboardButton implements Serializable {
     private boolean request_contact;
     private boolean request_location;
     private KeyboardButtonPollType request_poll;
+    private WebAppInfo web_app_info;
 
     public KeyboardButton(String text) {
         this.text = text;
@@ -30,6 +33,11 @@ public class KeyboardButton implements Serializable {
 
     public KeyboardButton requestPoll(KeyboardButtonPollType poll) {
         this.request_poll = poll;
+        return this;
+    }
+
+    public KeyboardButton webAppInfo(WebAppInfo webAppInfo) {
+        this.web_app_info = webAppInfo;
         return this;
     }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/request/AnswerWebAppQuery.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/AnswerWebAppQuery.java
@@ -1,0 +1,19 @@
+package com.pengrad.telegrambot.request;
+
+import com.pengrad.telegrambot.model.request.InlineQueryResult;
+import com.pengrad.telegrambot.response.BaseResponse;
+import com.pengrad.telegrambot.response.SentWebAppMessageResponse;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class AnswerWebAppQuery extends BaseRequest<AnswerWebAppQuery, SentWebAppMessageResponse> {
+
+    public AnswerWebAppQuery(String web_app_query_id, InlineQueryResult<?> result) {
+        super(SentWebAppMessageResponse.class);
+        add("web_app_query_id", web_app_query_id).add("result", result);
+    }
+
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/GetChatMenuButton.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/GetChatMenuButton.java
@@ -1,0 +1,19 @@
+package com.pengrad.telegrambot.request;
+
+import com.pengrad.telegrambot.response.GetChatMenuButtonResponse;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class GetChatMenuButton extends BaseRequest<GetChatMenuButton, GetChatMenuButtonResponse> {
+    
+    public GetChatMenuButton() {
+        super(GetChatMenuButtonResponse.class);
+    }
+
+    public GetChatMenuButton chatId(long chatId) {
+        return add("chat_id", chatId);
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/GetMyDefaultAdministratorRights.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/GetMyDefaultAdministratorRights.java
@@ -1,0 +1,19 @@
+package com.pengrad.telegrambot.request;
+
+import com.pengrad.telegrambot.response.GetMyDefaultAdministratorRightsResponse;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class GetMyDefaultAdministratorRights extends BaseRequest<GetMyDefaultAdministratorRights, GetMyDefaultAdministratorRightsResponse> {
+    
+    public GetMyDefaultAdministratorRights() {
+        super(GetMyDefaultAdministratorRightsResponse.class);
+    }
+
+    public GetMyDefaultAdministratorRights forChannels(boolean forChannels) {
+        return add("for_channels", forChannels);
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/PromoteChatMember.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/PromoteChatMember.java
@@ -37,8 +37,15 @@ public class PromoteChatMember extends BaseRequest<PromoteChatMember, BaseRespon
         return add("can_delete_messages", canDeleteMessages);
     }
 
+    /**
+     * @Deprecated Use canManageVideoChats(boolean canManageVideoChats) instead
+     */
     public PromoteChatMember canManageVoiceChats(boolean canManageVoiceChats) {
-        return add("can_manage_voice_chats", canManageVoiceChats);
+        return add("can_manage_video_chats", canManageVoiceChats);
+    }
+
+    public PromoteChatMember canManageVideoChats(boolean canManageVideoChats) {
+        return add("can_manage_video_chats", canManageVideoChats);
     }
 
     public PromoteChatMember canInviteUsers(boolean canInviteUsers) {

--- a/library/src/main/java/com/pengrad/telegrambot/request/SetChatMenuButton.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SetChatMenuButton.java
@@ -1,0 +1,24 @@
+package com.pengrad.telegrambot.request;
+
+import com.pengrad.telegrambot.model.MenuButton;
+import com.pengrad.telegrambot.response.BaseResponse;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class SetChatMenuButton extends BaseRequest<SetChatMenuButton, BaseResponse> {
+ 
+    public SetChatMenuButton() {
+        super(BaseResponse.class);
+    }
+
+    public SetChatMenuButton chatId(long chatId) {
+        return add("chat_id", chatId);
+    }
+
+    public SetChatMenuButton menuButton(MenuButton<?> menuButton) {
+        return add("menu_button", menuButton);
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/SetMyDefaultAdministratorRights.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SetMyDefaultAdministratorRights.java
@@ -1,0 +1,24 @@
+package com.pengrad.telegrambot.request;
+
+import com.pengrad.telegrambot.model.ChatAdministratorRights;
+import com.pengrad.telegrambot.response.BaseResponse;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class SetMyDefaultAdministratorRights extends BaseRequest<SetMyDefaultAdministratorRights, BaseResponse> {
+ 
+    public SetMyDefaultAdministratorRights() {
+        super(BaseResponse.class);
+    }
+
+    public SetMyDefaultAdministratorRights rights(ChatAdministratorRights chatAdministratorRights) {
+        return add("rights", chatAdministratorRights);
+    }
+
+    public SetMyDefaultAdministratorRights forChannels(boolean forChannels) {
+        return add("for_channels", forChannels);
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/response/GetChatMenuButtonResponse.java
+++ b/library/src/main/java/com/pengrad/telegrambot/response/GetChatMenuButtonResponse.java
@@ -1,0 +1,24 @@
+package com.pengrad.telegrambot.response;
+
+import com.pengrad.telegrambot.model.MenuButton;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class GetChatMenuButtonResponse extends BaseResponse {
+    
+    private MenuButton<?> result;
+
+    public MenuButton<?> result() {
+        return result;
+    }
+    
+    @Override
+    public String toString() {
+        return "GetChatMenuButtonResponse{" +
+                "result=" + result +
+                '}';
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/response/GetMyDefaultAdministratorRightsResponse.java
+++ b/library/src/main/java/com/pengrad/telegrambot/response/GetMyDefaultAdministratorRightsResponse.java
@@ -1,0 +1,24 @@
+package com.pengrad.telegrambot.response;
+
+import com.pengrad.telegrambot.model.ChatAdministratorRights;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class GetMyDefaultAdministratorRightsResponse extends BaseResponse {
+    
+    private ChatAdministratorRights result;
+
+    public ChatAdministratorRights result() {
+        return result;
+    }
+    
+    @Override
+    public String toString() {
+        return "GetMyDefaultAdministratorRightsResponse{" +
+                "result=" + result +
+                '}';
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/response/SentWebAppMessageResponse.java
+++ b/library/src/main/java/com/pengrad/telegrambot/response/SentWebAppMessageResponse.java
@@ -1,0 +1,22 @@
+package com.pengrad.telegrambot.response;
+
+/**
+ * Mirco Ianese
+ * 20 Apr 2022
+ */
+public class SentWebAppMessageResponse extends BaseResponse {
+   
+    private String inline_message_id;
+
+    public String inlineMessageId() {
+        return inline_message_id;
+    }
+
+    @Override
+    public String toString() {
+        return "SentWebAppMessageResponse{" +
+                "inline_message_id=" + inline_message_id +
+                '}';
+    }
+
+}


### PR DESCRIPTION
Hello,

I've implemented the changes for the version 6.0 as per [changelog](https://core.telegram.org/bots/api#april-16-2022).

This time the changes are a little bigger, so some tests should be written and run before merging.

I tried to keep the changes retro-compatible by using the "deprecated" tag on renames, but for the last [commit](https://github.com/pengrad/java-telegram-bot-api/commit/479f8872251bf18df5e6df72ab4688f3713b4b2c) I have directly renamed the classes (to keep the code cleaner), so it will not be retro-compatible. But it should be pretty easy for the final user to fix it's code, if it's specified in the readme.

This new version is pretty interesting thanks to the Javascript integration with BOTs, review this when you can! :) 

Thanks as always!