### PR TITLE
Change file_size fields type to Long

### DIFF
--- a/library/src/main/java/com/pengrad/telegrambot/model/Animation.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Animation.java
@@ -17,7 +17,7 @@ public class Animation implements Serializable {
     private PhotoSize thumb;
     private String file_name;
     private String mime_type;
-    private Integer file_size;
+    private Long file_size;
 
     public String fileId() {
         return file_id;
@@ -51,7 +51,7 @@ public class Animation implements Serializable {
         return mime_type;
     }
 
-    public Integer fileSize() {
+    public Long fileSize() {
         return file_size;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/Audio.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Audio.java
@@ -17,7 +17,7 @@ public class Audio implements Serializable {
     private String title;
     private String file_name;
     private String mime_type;
-    private Integer file_size;
+    private Long file_size;
     private PhotoSize thumb;
 
     public String fileId() {
@@ -48,7 +48,7 @@ public class Audio implements Serializable {
         return mime_type;
     }
 
-    public Integer fileSize() {
+    public Long fileSize() {
         return file_size;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/Document.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Document.java
@@ -14,7 +14,7 @@ public class Document implements Serializable {
     private PhotoSize thumb;
     private String file_name;
     private String mime_type;
-    private Integer file_size;
+    private Long file_size;
 
     public String fileId() {
         return file_id;
@@ -36,7 +36,7 @@ public class Document implements Serializable {
         return mime_type;
     }
 
-    public Integer fileSize() {
+    public Long fileSize() {
         return file_size;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/File.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/File.java
@@ -11,7 +11,7 @@ public class File implements Serializable {
 
     private String file_id;
     private String file_unique_id;
-    private Integer file_size;
+    private Long file_size;
     private String file_path;
 
     public String fileId() {
@@ -22,7 +22,7 @@ public class File implements Serializable {
         return file_unique_id;
     }
 
-    public Integer fileSize() {
+    public Long fileSize() {
         return file_size;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/PhotoSize.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/PhotoSize.java
@@ -13,7 +13,7 @@ public class PhotoSize implements Serializable {
     private String file_unique_id;
     private Integer width;
     private Integer height;
-    private Integer file_size;
+    private Long file_size;
 
     public String fileId() {
         return file_id;
@@ -31,7 +31,7 @@ public class PhotoSize implements Serializable {
         return height;
     }
 
-    public Integer fileSize() {
+    public Long fileSize() {
         return file_size;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/Sticker.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Sticker.java
@@ -20,7 +20,7 @@ public class Sticker implements Serializable {
     private String emoji;
     private String set_name;
     private MaskPosition mask_position;
-    private Integer file_size;
+    private Long file_size;
 
     public String fileId() {
         return file_id;
@@ -62,7 +62,7 @@ public class Sticker implements Serializable {
         return mask_position;
     }
 
-    public Integer fileSize() {
+    public Long fileSize() {
         return file_size;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/Video.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Video.java
@@ -18,7 +18,7 @@ public class Video implements Serializable {
     private PhotoSize thumb;
     private String file_name;
     private String mime_type;
-    private Integer file_size;
+    private Long file_size;
 
     public String fileId() {
         return file_id;
@@ -52,7 +52,7 @@ public class Video implements Serializable {
         return mime_type;
     }
 
-    public Integer fileSize() {
+    public Long fileSize() {
         return file_size;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/VideoNote.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/VideoNote.java
@@ -14,7 +14,7 @@ public class VideoNote implements Serializable {
     private Integer length;
     private Integer duration;
     private PhotoSize thumb;
-    private Integer file_size;
+    private Long file_size;
 
     public String fileId() {
         return file_id;
@@ -36,7 +36,7 @@ public class VideoNote implements Serializable {
         return thumb;
     }
 
-    public Integer fileSize() {
+    public Long fileSize() {
         return file_size;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/Voice.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Voice.java
@@ -13,7 +13,7 @@ public class Voice implements Serializable {
     private String file_unique_id;
     private Integer duration;
     private String mime_type;
-    private Integer file_size;
+    private Long file_size;
 
     public String fileId() {
         return file_id;
@@ -31,7 +31,7 @@ public class Voice implements Serializable {
         return mime_type;
     }
 
-    public Integer fileSize() {
+    public Long fileSize() {
         return file_size;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/passport/PassportFile.java
+++ b/library/src/main/java/com/pengrad/telegrambot/passport/PassportFile.java
@@ -11,7 +11,7 @@ public class PassportFile implements Serializable {
 
     private String file_id;
     private String file_unique_id;
-    private Integer file_size;
+    private Long file_size;
     private Integer file_date;
 
     public String fileId() {
@@ -22,7 +22,7 @@ public class PassportFile implements Serializable {
         return file_unique_id;
     }
 
-    public Integer fileSize() {
+    public Long fileSize() {
         return file_size;
     }
 

--- a/library/src/test/java/com/pengrad/telegrambot/TelegramBotTest.java
+++ b/library/src/test/java/com/pengrad/telegrambot/TelegramBotTest.java
@@ -191,7 +191,7 @@ public class TelegramBotTest {
     //    static String imageUrl = "https://telegram.org/img/t_logo.png";
     static File thumbFile = resourcePath.resolve("thumb.jpg").toFile();
     static byte[] thumbBytes;
-    static Integer thumbSize = 3718;
+    static Long thumbSize = 3718L;
     static File gifFile = resourcePath.resolve("anim3.gif").toFile();
     static byte[] gifBytes;
 
@@ -1555,22 +1555,22 @@ public class TelegramBotTest {
         assertEquals(Integer.valueOf(3), response.message().animation().duration());
         assertNotEquals(gifFileId, response.message().animation().fileId());
         assertNotNull(response.message().document());
-        assertEquals((Integer) 57527, response.message().document().fileSize());
+        assertEquals(Long.valueOf(57527), response.message().document().fileSize());
         assertEquals("video/mp4", response.message().document().mimeType());
 
         response = (SendResponse) bot.execute(new EditMessageMedia(chatId, messageId, new InputMediaAudio(audioFileId)));
-        assertEquals((Integer) 10286, response.message().audio().fileSize());
+        assertEquals(Long.valueOf(10286), response.message().audio().fileSize());
         response = (SendResponse) bot.execute(new EditMessageMedia(chatId, messageId, new InputMediaAudio(audioFile)));
-        assertEquals((Integer) 10286, response.message().audio().fileSize());
+        assertEquals(Long.valueOf(10286), response.message().audio().fileSize());
         response = (SendResponse) bot.execute(new EditMessageMedia(chatId, messageId, new InputMediaAudio(audioBytes)));
-        assertEquals((Integer) 10286, response.message().audio().fileSize());
+        assertEquals(Long.valueOf(10286), response.message().audio().fileSize());
         Integer duration = 34;
         String performer = "some performer", title = "just a title", fileName = "beep.mp3";
         response = (SendResponse) bot.execute(new EditMessageMedia(chatId, messageId,
                 new InputMediaAudio(audioFile).duration(duration).performer(performer).title(title)
         ));
         Audio audio = response.message().audio();
-        assertEquals((Integer) 10286, audio.fileSize());
+        assertEquals(Long.valueOf(10286), audio.fileSize());
         assertEquals(duration, audio.duration());
         assertEquals(performer, audio.performer());
         assertEquals(title, audio.title());
@@ -1670,7 +1670,7 @@ public class TelegramBotTest {
             }
 
             if (encElement.type() == EncryptedPassportElement.Type.passport) {
-                assertEquals(Integer.valueOf(260608), encElement.frontSide().fileSize());
+                assertEquals(Long.valueOf(260608), encElement.frontSide().fileSize());
                 assertEquals(Integer.valueOf(1535386777), encElement.frontSide().fileDate());
 
                 List<PassportFile> files = new ArrayList<>();


### PR DESCRIPTION
Hello,

according to a recent Telegram BOT news post:

> As of the next update, it will no longer be possible to store the value of file_size fields in a signed 32-bit integer type. This change is necessary to support 4GB files which some users will be able to upload. We expect this update to arrive in June 2022.

For this reason I've changed all the `file_size` fields to Long type.