### PR TITLE
BOT Api v6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov](https://codecov.io/gh/pengrad/java-telegram-bot-api/branch/master/graph/badge.svg)](https://codecov.io/gh/pengrad/java-telegram-bot-api)
 
 Java library for interacting with [Telegram Bot API](https://core.telegram.org/bots/api)
-- Full support of all Bot API 6.3 methods
+- Full support of all Bot API 6.4 methods
 - Telegram [Passport](https://core.telegram.org/passport) and Decryption API
 - Bot [Payments](https://core.telegram.org/bots/payments)
 - [Gaming Platform](https://telegram.org/blog/games)
@@ -14,14 +14,14 @@ Java library for interacting with [Telegram Bot API](https://core.telegram.org/b
 
 Gradle:
 ```groovy
-implementation 'com.github.pengrad:java-telegram-bot-api:6.3.0'
+implementation 'com.github.pengrad:java-telegram-bot-api:6.4.0'
 ```
 Maven:
 ```xml
 <dependency>
   <groupId>com.github.pengrad</groupId>
   <artifactId>java-telegram-bot-api</artifactId>
-  <version>6.3.0</version>
+  <version>6.4.0</version>
 </dependency>
 ```
 [JAR with all dependencies on release page](https://github.com/pengrad/java-telegram-bot-api/releases)

--- a/README_RU.md
+++ b/README_RU.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/pengrad/java-telegram-bot-api/branch/master/graph/badge.svg)](https://codecov.io/gh/pengrad/java-telegram-bot-api)
 
 Java библиотека, созданная для работы с [Telegram Bot API](https://core.telegram.org/bots/api)
-- Полная поддержка всех методов BOT API 6.3
+- Полная поддержка всех методов BOT API 6.4
 - Поддержка Telegram [паспорта](https://core.telegram.org/passport) и дешифровки (Decryption API);
 - Поддержка [платежей](https://core.telegram.org/bots/payments);
 - [Игровая платформа](https://telegram.org/blog/games).
@@ -13,14 +13,14 @@ Java библиотека, созданная для работы с [Telegram B
 
 Gradle:
 ```groovy
-implementation 'com.github.pengrad:java-telegram-bot-api:6.3.0'
+implementation 'com.github.pengrad:java-telegram-bot-api:6.4.0'
 ```
 Maven:
 ```xml
 <dependency>
   <groupId>com.github.pengrad</groupId>
   <artifactId>java-telegram-bot-api</artifactId>
-  <version>6.3.0</version>
+  <version>6.4.0</version>
 </dependency>
 ```
 Также JAR со всеми зависимостями можно найти [в релизах](https://github.com/pengrad/java-telegram-bot-api/releases).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.github.pengrad
-VERSION_NAME=6.3.0
+VERSION_NAME=6.4.0
 
 POM_DESCRIPTION=Java API for Telegram Bot API
 POM_URL=https://github.com/pengrad/java-telegram-bot-api/

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/library/src/main/java/com/pengrad/telegrambot/model/Chat.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Chat.java
@@ -37,6 +37,7 @@ public class Chat implements Serializable {
     private String bio;
     private Boolean has_private_forwards;
     private Boolean has_restricted_voice_and_video_messages;
+    private Boolean has_hidden_members;
     private Boolean join_to_send_messages;
     private Boolean join_by_request;
     private String description;
@@ -101,6 +102,10 @@ public class Chat implements Serializable {
 
     public Boolean hasRestrictedVoiceAndVideoMessages() {
         return has_restricted_voice_and_video_messages != null && has_restricted_voice_and_video_messages;
+    }
+
+    public Boolean hasHiddenMembers() {
+        return has_hidden_members != null && has_hidden_members;
     }
 
     public Boolean joinToSendMessages() {
@@ -173,6 +178,7 @@ public class Chat implements Serializable {
                 Objects.equals(bio, chat.bio) &&
                 Objects.equals(has_private_forwards, chat.has_private_forwards) &&
                 Objects.equals(has_restricted_voice_and_video_messages, chat.has_restricted_voice_and_video_messages) &&
+                Objects.equals(has_hidden_members, chat.has_hidden_members) &&
                 Objects.equals(join_to_send_messages, chat.join_to_send_messages) &&
                 Objects.equals(join_by_request, chat.join_by_request) &&
                 Objects.equals(description, chat.description) &&
@@ -209,6 +215,7 @@ public class Chat implements Serializable {
                 ", bio='" + bio + '\'' +
                 ", has_private_forwards=" + has_private_forwards +
                 ", has_restricted_voice_and_video_messages=" + has_restricted_voice_and_video_messages +
+                ", has_hidden_members=" + has_hidden_members +
                 ", join_to_send_messages=" + join_to_send_messages +
                 ", join_by_request=" + join_by_request +
                 ", description='" + description + '\'' +

--- a/library/src/main/java/com/pengrad/telegrambot/model/Chat.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Chat.java
@@ -38,6 +38,7 @@ public class Chat implements Serializable {
     private Boolean has_private_forwards;
     private Boolean has_restricted_voice_and_video_messages;
     private Boolean has_hidden_members;
+    private Boolean has_aggressive_anti_spam_enabled;
     private Boolean join_to_send_messages;
     private Boolean join_by_request;
     private String description;
@@ -106,6 +107,10 @@ public class Chat implements Serializable {
 
     public Boolean hasHiddenMembers() {
         return has_hidden_members != null && has_hidden_members;
+    }
+
+    public Boolean hasAggressiveAntiSpamEnabled() {
+        return has_aggressive_anti_spam_enabled != null && has_aggressive_anti_spam_enabled;
     }
 
     public Boolean joinToSendMessages() {
@@ -179,6 +184,7 @@ public class Chat implements Serializable {
                 Objects.equals(has_private_forwards, chat.has_private_forwards) &&
                 Objects.equals(has_restricted_voice_and_video_messages, chat.has_restricted_voice_and_video_messages) &&
                 Objects.equals(has_hidden_members, chat.has_hidden_members) &&
+                Objects.equals(has_aggressive_anti_spam_enabled, chat.has_aggressive_anti_spam_enabled) &&
                 Objects.equals(join_to_send_messages, chat.join_to_send_messages) &&
                 Objects.equals(join_by_request, chat.join_by_request) &&
                 Objects.equals(description, chat.description) &&
@@ -216,6 +222,7 @@ public class Chat implements Serializable {
                 ", has_private_forwards=" + has_private_forwards +
                 ", has_restricted_voice_and_video_messages=" + has_restricted_voice_and_video_messages +
                 ", has_hidden_members=" + has_hidden_members +
+                ", has_aggressive_anti_spam_enabled=" + has_aggressive_anti_spam_enabled +
                 ", join_to_send_messages=" + join_to_send_messages +
                 ", join_by_request=" + join_by_request +
                 ", description='" + description + '\'' +

--- a/library/src/main/java/com/pengrad/telegrambot/model/ForumTopicEdited.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/ForumTopicEdited.java
@@ -1,0 +1,44 @@
+package com.pengrad.telegrambot.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class ForumTopicEdited implements Serializable {
+    private final static long serialVersionUID = 0L;
+
+    private String name;
+    private String icon_custom_emoji_id;
+
+    public String name() {
+        return name;
+    }
+
+    public String iconCustomEmojiId() {
+        return icon_custom_emoji_id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ForumTopicEdited that = (ForumTopicEdited) o;
+
+        return Objects.equals(name, that.name) &&
+                Objects.equals(icon_custom_emoji_id, that.icon_custom_emoji_id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name,
+                icon_custom_emoji_id);
+    }
+
+    @Override
+    public String toString() {
+        return "ForumTopicEdited{" +
+                "name='" + name + '\'' +
+                ", icon_custom_emoji_id='" + icon_custom_emoji_id + '\'' +
+                '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/GeneralForumTopicHidden.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/GeneralForumTopicHidden.java
@@ -1,0 +1,18 @@
+package com.pengrad.telegrambot.model;
+
+import java.io.Serializable;
+
+public class GeneralForumTopicHidden implements Serializable {
+    private final static long serialVersionUID = 0L;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/GeneralForumTopicUnhidden.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/GeneralForumTopicUnhidden.java
@@ -1,0 +1,18 @@
+package com.pengrad.telegrambot.model;
+
+import java.io.Serializable;
+
+public class GeneralForumTopicUnhidden implements Serializable {
+    private final static long serialVersionUID = 0L;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/Message.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Message.java
@@ -32,6 +32,7 @@ public class Message implements Serializable {
     private User via_bot;
     private Integer edit_date;
     private Boolean has_protected_content;
+    private Boolean has_media_spoiler;
     private String media_group_id;
     private String author_signature;
     private String text;
@@ -150,6 +151,11 @@ public class Message implements Serializable {
     public Boolean hasProtectedContent() {
         return has_protected_content;
     }
+
+    public Boolean hasMediaSpoiler() {
+        return has_media_spoiler;
+    }
+
 
     public String mediaGroupId() {
         return media_group_id;
@@ -358,6 +364,7 @@ public class Message implements Serializable {
                 Objects.equals(via_bot, message.via_bot) &&
                 Objects.equals(edit_date, message.edit_date) &&
                 Objects.equals(has_protected_content, message.has_protected_content) &&
+                Objects.equals(has_media_spoiler, message.has_media_spoiler) &&
                 Objects.equals(media_group_id, message.media_group_id) &&
                 Objects.equals(author_signature, message.author_signature) &&
                 Objects.equals(text, message.text) &&
@@ -432,6 +439,7 @@ public class Message implements Serializable {
                 ", via_bot=" + via_bot +
                 ", edit_date=" + edit_date +
                 ", has_protected_content=" + has_protected_content+
+                ", has_media_spoiler=" + has_media_spoiler+
                 ", media_group_id='" + media_group_id + '\'' +
                 ", author_signature='" + author_signature + '\'' +
                 ", text='" + text + '\'' +

--- a/library/src/main/java/com/pengrad/telegrambot/model/Message.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Message.java
@@ -71,8 +71,13 @@ public class Message implements Serializable {
     private PassportData passport_data;
     private ProximityAlertTriggered proximity_alert_triggered;
     private ForumTopicCreated forum_topic_created;
+    private ForumTopicEdited forum_topic_edited;
     private ForumTopicClosed forum_topic_closed;
     private ForumTopicReopened forum_topic_reopened;
+    private GeneralForumTopicHidden general_forum_topic_hidden;
+    private GeneralForumTopicUnhidden general_forum_topic_unhidden;
+    private WriteAccessAllowed write_access_allowed;
+
     private VideoChatStarted video_chat_started;
     private VideoChatEnded video_chat_ended;
     private VideoChatParticipantsInvited video_chat_participants_invited;
@@ -309,12 +314,28 @@ public class Message implements Serializable {
         return forum_topic_created;
     }
 
+    public ForumTopicEdited forumTopicEdited() {
+        return forum_topic_edited;
+    }
+
     public ForumTopicClosed forumTopicClosed() {
         return forum_topic_closed;
     }
 
     public ForumTopicReopened forumTopicReopened() {
         return forum_topic_reopened;
+    }
+
+    public GeneralForumTopicHidden generalForumTopicHidden() {
+        return general_forum_topic_hidden;
+    }
+
+    public GeneralForumTopicUnhidden generalForumTopicUnhidden() {
+        return general_forum_topic_unhidden;
+    }
+
+    public WriteAccessAllowed writeAccessAllowed() {
+        return write_access_allowed;
     }
 
     public VideoChatStarted videoChatStarted() {
@@ -403,8 +424,12 @@ public class Message implements Serializable {
                 Objects.equals(passport_data, message.passport_data) &&
                 Objects.equals(proximity_alert_triggered, message.proximity_alert_triggered) &&
                 Objects.equals(forum_topic_created, message.forum_topic_created) &&
+                Objects.equals(forum_topic_edited, message.forum_topic_edited) &&
                 Objects.equals(forum_topic_closed, message.forum_topic_closed) &&
                 Objects.equals(forum_topic_reopened, message.forum_topic_reopened) &&
+                Objects.equals(general_forum_topic_hidden, message.general_forum_topic_hidden) &&
+                Objects.equals(general_forum_topic_unhidden, message.general_forum_topic_unhidden) &&
+                Objects.equals(write_access_allowed, message.write_access_allowed) &&
                 Objects.equals(video_chat_started, message.video_chat_started) &&
                 Objects.equals(video_chat_ended, message.video_chat_ended) &&
                 Objects.equals(video_chat_participants_invited, message.video_chat_participants_invited) &&
@@ -478,8 +503,12 @@ public class Message implements Serializable {
                 ", passport_data=" + passport_data +
                 ", proximity_alert_triggered=" + proximity_alert_triggered +
                 ", forum_topic_created=" + forum_topic_created +
+                ", forum_topic_edited=" + forum_topic_edited +
                 ", forum_topic_closed=" + forum_topic_closed +
                 ", forum_topic_reopened=" + forum_topic_reopened +
+                ", general_forum_topic_hidden=" + general_forum_topic_hidden +
+                ", general_forum_topic_unhidden=" + general_forum_topic_unhidden +
+                ", write_access_allowed=" + write_access_allowed +
                 ", video_chat_started=" + video_chat_started +
                 ", video_chat_ended=" + video_chat_ended +
                 ", video_chat_participants_invited=" + video_chat_participants_invited +

--- a/library/src/main/java/com/pengrad/telegrambot/model/WriteAccessAllowed.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/WriteAccessAllowed.java
@@ -1,0 +1,18 @@
+package com.pengrad.telegrambot.model;
+
+import java.io.Serializable;
+
+public class WriteAccessAllowed implements Serializable {
+    private final static long serialVersionUID = 0L;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/request/InputMediaAnimation.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/request/InputMediaAnimation.java
@@ -13,6 +13,7 @@ public class InputMediaAnimation extends InputMedia<InputMediaAnimation> impleme
     private final static long serialVersionUID = 0L;
 
     private Integer width, height, duration;
+    private Boolean has_spoiler;
 
     public InputMediaAnimation(String media) {
         super("animation", media);
@@ -38,6 +39,11 @@ public class InputMediaAnimation extends InputMedia<InputMediaAnimation> impleme
 
     public InputMediaAnimation duration(Integer duration) {
         this.duration = duration;
+        return this;
+    }
+
+    public InputMediaAnimation hasSpoiler(boolean has_spoiler) {
+        this.has_spoiler = has_spoiler;
         return this;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/request/InputMediaPhoto.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/request/InputMediaPhoto.java
@@ -12,6 +12,8 @@ import java.io.Serializable;
 public class InputMediaPhoto extends InputMedia<InputMediaPhoto> implements Serializable {
     private final static long serialVersionUID = 1L;
 
+    private Boolean has_spoiler;
+
     public InputMediaPhoto(String media) {
         super("photo", media);
     }
@@ -22,6 +24,11 @@ public class InputMediaPhoto extends InputMedia<InputMediaPhoto> implements Seri
 
     public InputMediaPhoto(byte[] media) {
         super("photo", media);
+    }
+
+    public InputMediaPhoto hasSpoiler(boolean has_spoiler) {
+        this.has_spoiler = has_spoiler;
+        return this;
     }
 
     @Override

--- a/library/src/main/java/com/pengrad/telegrambot/model/request/InputMediaVideo.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/request/InputMediaVideo.java
@@ -14,6 +14,7 @@ public class InputMediaVideo extends InputMedia<InputMediaVideo> implements Seri
 
     private Integer width, height, duration;
     private Boolean supports_streaming;
+    private Boolean has_spoiler;
 
     public InputMediaVideo(String media) {
         super("video", media);
@@ -44,6 +45,11 @@ public class InputMediaVideo extends InputMedia<InputMediaVideo> implements Seri
 
     public InputMediaVideo supportsStreaming(boolean supportsStreaming) {
         this.supports_streaming = supportsStreaming;
+        return this;
+    }
+
+    public InputMediaVideo hasSpoiler(boolean has_spoiler) {
+        this.has_spoiler = has_spoiler;
         return this;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/request/ReplyKeyboardMarkup.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/request/ReplyKeyboardMarkup.java
@@ -17,24 +17,26 @@ public class ReplyKeyboardMarkup extends Keyboard implements Serializable {
     private boolean one_time_keyboard;
     private String input_field_placeholder;
     private boolean selective;
+    private boolean is_persistent;
 
-    public ReplyKeyboardMarkup(String[][] keyboard, boolean resize_keyboard, boolean one_time_keyboard, String input_field_placeholder, boolean selective) {
+    public ReplyKeyboardMarkup(String[][] keyboard, boolean resize_keyboard, boolean one_time_keyboard, String input_field_placeholder, boolean selective, boolean is_persistent) {
         this.keyboard = new ArrayList<>();
         this.resize_keyboard = resize_keyboard;
         this.one_time_keyboard = one_time_keyboard;
         this.input_field_placeholder = input_field_placeholder;
         this.selective = selective;
+        this.is_persistent = is_persistent;
         for (String[] line : keyboard) {
             addRow(line);
         }
     }
 
-    public ReplyKeyboardMarkup(String[][] keyboard, boolean resize_keyboard, boolean one_time_keyboard, boolean selective) {
-        this(keyboard, resize_keyboard, one_time_keyboard, null, selective);
+    public ReplyKeyboardMarkup(String[][] keyboard, boolean resize_keyboard, boolean one_time_keyboard, boolean selective, boolean is_persistent) {
+        this(keyboard, resize_keyboard, one_time_keyboard, null, selective, is_persistent);
     }
 
     public ReplyKeyboardMarkup(String[]... keyboard) {
-        this(keyboard, false, false, false);
+        this(keyboard, false, false, false, false);
     }
 
     public ReplyKeyboardMarkup(KeyboardButton[]... keyboard) {
@@ -83,6 +85,11 @@ public class ReplyKeyboardMarkup extends Keyboard implements Serializable {
 
     public ReplyKeyboardMarkup selective(boolean selective) {
         this.selective = selective;
+        return this;
+    }
+
+    public ReplyKeyboardMarkup isPersistent(boolean is_persistent) {
+        this.is_persistent = is_persistent;
         return this;
     }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/request/CloseForumTopic.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/CloseForumTopic.java
@@ -3,7 +3,7 @@ package com.pengrad.telegrambot.request;
 import com.pengrad.telegrambot.response.BaseResponse;
 
 public class CloseForumTopic extends BaseRequest<CloseForumTopic, BaseResponse> {
-    public CloseForumTopic(Integer chatId, Integer messageThreadId) {
+    public CloseForumTopic(Long chatId, Integer messageThreadId) {
         super(BaseResponse.class);
         add("chat_id", chatId);
         add("message_thread_id", messageThreadId);

--- a/library/src/main/java/com/pengrad/telegrambot/request/CloseGeneralForumTopic.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/CloseGeneralForumTopic.java
@@ -1,0 +1,17 @@
+package com.pengrad.telegrambot.request;
+
+import com.pengrad.telegrambot.response.BaseResponse;
+
+public class CloseGeneralForumTopic extends BaseRequest<CloseGeneralForumTopic, BaseResponse> {
+
+    public CloseGeneralForumTopic(Long chatId) {
+        super(BaseResponse.class);
+        add("chat_id", chatId);
+    }
+
+    public CloseGeneralForumTopic(String chatId) {
+        super(BaseResponse.class);
+        add("chat_id", chatId);
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/CreateForumTopic.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/CreateForumTopic.java
@@ -10,7 +10,7 @@ public class CreateForumTopic extends BaseRequest<CreateForumTopic, CreateForumT
         add("name", name);
     }
 
-    public CreateForumTopic(Integer chatId, String name) {
+    public CreateForumTopic(Long chatId, String name) {
         super(CreateForumTopicResponse.class);
         add("chat_id", chatId);
         add("name", name);

--- a/library/src/main/java/com/pengrad/telegrambot/request/DeleteForumTopic.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/DeleteForumTopic.java
@@ -3,7 +3,7 @@ package com.pengrad.telegrambot.request;
 import com.pengrad.telegrambot.response.BaseResponse;
 
 public class DeleteForumTopic extends BaseRequest<DeleteForumTopic, BaseResponse> {
-    public DeleteForumTopic(Integer chatId, Integer messageThreadId) {
+    public DeleteForumTopic(Long chatId, Integer messageThreadId) {
         super(BaseResponse.class);
         add("chat_id", chatId);
         add("message_thread_id", messageThreadId);

--- a/library/src/main/java/com/pengrad/telegrambot/request/EditForumTopic.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/EditForumTopic.java
@@ -4,7 +4,7 @@ import com.pengrad.telegrambot.response.BaseResponse;
 
 public class EditForumTopic extends BaseRequest<EditForumTopic, BaseResponse> {
 
-    public EditForumTopic(Integer chatId,
+    public EditForumTopic(Long chatId,
                           Integer messageThreadId) {
         super(BaseResponse.class);
         add("chat_id", chatId);
@@ -18,7 +18,7 @@ public class EditForumTopic extends BaseRequest<EditForumTopic, BaseResponse> {
         add("message_thread_id", messageThreadId);
     }
 
-    public EditForumTopic(Integer chatId,
+    public EditForumTopic(Long chatId,
                           Integer messageThreadId,
                           String name,
                           String iconCustomEmojiId) {

--- a/library/src/main/java/com/pengrad/telegrambot/request/EditForumTopic.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/EditForumTopic.java
@@ -3,6 +3,21 @@ package com.pengrad.telegrambot.request;
 import com.pengrad.telegrambot.response.BaseResponse;
 
 public class EditForumTopic extends BaseRequest<EditForumTopic, BaseResponse> {
+
+    public EditForumTopic(Integer chatId,
+                          Integer messageThreadId) {
+        super(BaseResponse.class);
+        add("chat_id", chatId);
+        add("message_thread_id", messageThreadId);
+    }
+
+    public EditForumTopic(String chatId,
+                          Integer messageThreadId) {
+        super(BaseResponse.class);
+        add("chat_id", chatId);
+        add("message_thread_id", messageThreadId);
+    }
+
     public EditForumTopic(Integer chatId,
                           Integer messageThreadId,
                           String name,
@@ -24,4 +39,16 @@ public class EditForumTopic extends BaseRequest<EditForumTopic, BaseResponse> {
         add("name", name);
         add("icon_custom_emoji_id", iconCustomEmojiId);
     }
+
+
+    public EditForumTopic name(String name) {
+        add("name", name);
+        return this;
+    }
+
+    public EditForumTopic iconCustomEmojiId(String icon_custom_emoji_id) {
+        add("icon_custom_emoji_id", icon_custom_emoji_id);
+        return this;
+    }
+
 }

--- a/library/src/main/java/com/pengrad/telegrambot/request/EditGeneralForumTopic.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/EditGeneralForumTopic.java
@@ -1,0 +1,19 @@
+package com.pengrad.telegrambot.request;
+
+import com.pengrad.telegrambot.response.BaseResponse;
+
+public class EditGeneralForumTopic extends BaseRequest<EditGeneralForumTopic, BaseResponse> {
+
+    public EditGeneralForumTopic(Long chatId, String name) {
+        super(BaseResponse.class);
+        add("chat_id", chatId);
+        add("name", name);
+    }
+
+    public EditGeneralForumTopic(String chatId, String name) {
+        super(BaseResponse.class);
+        add("chat_id", chatId);
+        add("name", name);
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/HideGeneralForumTopic.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/HideGeneralForumTopic.java
@@ -1,0 +1,17 @@
+package com.pengrad.telegrambot.request;
+
+import com.pengrad.telegrambot.response.BaseResponse;
+
+public class HideGeneralForumTopic extends BaseRequest<HideGeneralForumTopic, BaseResponse> {
+
+    public HideGeneralForumTopic(Long chatId) {
+        super(BaseResponse.class);
+        add("chat_id", chatId);
+    }
+
+    public HideGeneralForumTopic(String chatId) {
+        super(BaseResponse.class);
+        add("chat_id", chatId);
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/ReopenForumTopic.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/ReopenForumTopic.java
@@ -3,7 +3,7 @@ package com.pengrad.telegrambot.request;
 import com.pengrad.telegrambot.response.BaseResponse;
 
 public class ReopenForumTopic extends BaseRequest<ReopenForumTopic, BaseResponse> {
-    public ReopenForumTopic(Integer chatId, Integer messageThreadId) {
+    public ReopenForumTopic(Long chatId, Integer messageThreadId) {
         super(BaseResponse.class);
         add("chat_id", chatId);
         add("message_thread_id", messageThreadId);

--- a/library/src/main/java/com/pengrad/telegrambot/request/ReopenGeneralForumTopic.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/ReopenGeneralForumTopic.java
@@ -1,0 +1,17 @@
+package com.pengrad.telegrambot.request;
+
+import com.pengrad.telegrambot.response.BaseResponse;
+
+public class ReopenGeneralForumTopic extends BaseRequest<ReopenGeneralForumTopic, BaseResponse> {
+
+    public ReopenGeneralForumTopic(Long chatId) {
+        super(BaseResponse.class);
+        add("chat_id", chatId);
+    }
+
+    public ReopenGeneralForumTopic(String chatId) {
+        super(BaseResponse.class);
+        add("chat_id", chatId);
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/SendAnimation.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SendAnimation.java
@@ -55,6 +55,10 @@ public class SendAnimation extends AbstractMultipartRequest<SendAnimation> {
         return add("caption_entities", entities);
     }
 
+    public SendAnimation hasSpoiler(boolean has_spoiler) {
+        return add("has_spoiler", has_spoiler);
+    }
+
     @Override
     protected String getFileParamName() {
         return "animation";

--- a/library/src/main/java/com/pengrad/telegrambot/request/SendChatAction.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SendChatAction.java
@@ -18,4 +18,9 @@ public class SendChatAction extends BaseRequest<SendChatAction, BaseResponse> {
         super(BaseResponse.class);
         add("chat_id", chatId).add("action", action.name());
     }
+
+    public SendChatAction messageThreadId(int message_thread_id) {
+        add("message_thread_id", message_thread_id);
+        return this;
+    }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/request/SendPhoto.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SendPhoto.java
@@ -35,6 +35,10 @@ public class SendPhoto extends AbstractMultipartRequest<SendPhoto> {
         return add("caption_entities", entities);
     }
 
+    public SendPhoto hasSpoiler(boolean has_spoiler) {
+        return add("has_spoiler", has_spoiler);
+    }
+
     @Override
     protected String getFileParamName() {
         return "photo";

--- a/library/src/main/java/com/pengrad/telegrambot/request/SendVideo.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SendVideo.java
@@ -59,6 +59,10 @@ public class SendVideo extends AbstractMultipartRequest<SendVideo> {
         return add("supports_streaming", supportsStreaming);
     }
 
+    public SendVideo hasSpoiler(boolean has_spoiler) {
+        return add("has_spoiler", has_spoiler);
+    }
+
     @Override
     protected String getFileParamName() {
         return "video";

--- a/library/src/main/java/com/pengrad/telegrambot/request/UnhideGeneralForumTopic.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/UnhideGeneralForumTopic.java
@@ -1,0 +1,17 @@
+package com.pengrad.telegrambot.request;
+
+import com.pengrad.telegrambot.response.BaseResponse;
+
+public class UnhideGeneralForumTopic extends BaseRequest<UnhideGeneralForumTopic, BaseResponse> {
+
+    public UnhideGeneralForumTopic(Long chatId) {
+        super(BaseResponse.class);
+        add("chat_id", chatId);
+    }
+
+    public UnhideGeneralForumTopic(String chatId) {
+        super(BaseResponse.class);
+        add("chat_id", chatId);
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/UnpinAllForumTopicMessages.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/UnpinAllForumTopicMessages.java
@@ -3,7 +3,7 @@ package com.pengrad.telegrambot.request;
 import com.pengrad.telegrambot.response.BaseResponse;
 
 public class UnpinAllForumTopicMessages extends BaseRequest<UnpinAllForumTopicMessages, BaseResponse> {
-    public UnpinAllForumTopicMessages(Integer chatId, Integer messageThreadId) {
+    public UnpinAllForumTopicMessages(Long chatId, Integer messageThreadId) {
         super(BaseResponse.class);
         add("chat_id", chatId);
         add("message_thread_id", messageThreadId);

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.pengrad</groupId>
   <artifactId>java-telegram-bot-api</artifactId>
-  <version>6.3.0</version>
+  <version>6.4.0</version>
   <name>JavaTelegramBotApi</name>
   <description>Java API for Telegram Bot API</description>
   <url>https://github.com/pengrad/java-telegram-bot-api/</url>


### PR DESCRIPTION
Hello,

I've implemented the changes for the version 6.4 as per [changelog](https://core.telegram.org/bots/api-changelog#december-30-2022).

I will also make another PR for the v6.5 API update that was just released.

Note, [this](https://github.com/pengrad/java-telegram-bot-api/commit/174d79eb8d994a22ebe67e9963fcd61746fff0f6) commit changes the data type used for chatId fields from Integer to Long. 
Telegram documentation states that "Integer" is used for those data types, but I think it will be safer and more future-proof to use 64bit integers, as Telegram is already using those for chat Ids (at least for users).

Thanks!