### PR TITLE
Added Manifest attribute to enable usage inside Java 9 modules

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -14,6 +14,12 @@ dependencies {
     testCompile 'org.reflections:reflections:0.9.12'
 }
 
+jar {
+    manifest {
+        attributes "Automatic-Module-Name": "telegram.bot.api"
+    }
+}
+
 jacoco {
     toolVersion = "0.8.5"
 }


### PR DESCRIPTION
With this attribute the project can be added with ease inside Gradle project that use Java 9 modules.