### PR TITLE
Implement Bot API 7.0 Reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Java library for interacting with [Telegram Bot API](https://core.telegram.org/b
 
 Gradle:
 ```groovy
-implementation 'com.github.pengrad:java-telegram-bot-api:6.9.1'
+implementation 'com.github.pengrad:java-telegram-bot-api:7.0.0'
 ```
 Maven:
 ```xml
 <dependency>
   <groupId>com.github.pengrad</groupId>
   <artifactId>java-telegram-bot-api</artifactId>
-  <version>6.9.1</version>
+  <version>7.0.0</version>
 </dependency>
 ```
 [JAR with all dependencies on release page](https://github.com/pengrad/java-telegram-bot-api/releases)

--- a/README_RU.md
+++ b/README_RU.md
@@ -13,14 +13,14 @@ Java библиотека, созданная для работы с [Telegram B
 
 Gradle:
 ```groovy
-implementation 'com.github.pengrad:java-telegram-bot-api:6.9.1'
+implementation 'com.github.pengrad:java-telegram-bot-api:7.0.0'
 ```
 Maven:
 ```xml
 <dependency>
   <groupId>com.github.pengrad</groupId>
   <artifactId>java-telegram-bot-api</artifactId>
-  <version>6.9.1</version>
+  <version>7.0.0</version>
 </dependency>
 ```
 Также JAR со всеми зависимостями можно найти [в релизах](https://github.com/pengrad/java-telegram-bot-api/releases).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.github.pengrad
-VERSION_NAME=6.9.1
+VERSION_NAME=7.0.0
 
 POM_DESCRIPTION=Java API for Telegram Bot API
 POM_URL=https://github.com/pengrad/java-telegram-bot-api/

--- a/library/src/main/java/com/pengrad/telegrambot/BotUtils.java
+++ b/library/src/main/java/com/pengrad/telegrambot/BotUtils.java
@@ -1,7 +1,10 @@
 package com.pengrad.telegrambot;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.pengrad.telegrambot.model.Update;
+import com.pengrad.telegrambot.model.reaction.ReactionType;
+import com.pengrad.telegrambot.utility.gson.ReactionTypeAdapter;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -16,14 +19,16 @@ public class BotUtils {
 
     private BotUtils() {}
 
-    private static final Gson gson = new Gson();
+    public static final Gson GSON = new GsonBuilder()
+        .registerTypeAdapter(ReactionType.class, new ReactionTypeAdapter())
+        .create();
 
     public static Update parseUpdate(String update) {
-        return gson.fromJson(update, Update.class);
+        return GSON.fromJson(update, Update.class);
     }
 
     public static Update parseUpdate(Reader reader) {
-        return gson.fromJson(reader, Update.class);
+        return GSON.fromJson(reader, Update.class);
     }
 
     static byte[] getBytesFromInputStream(InputStream is) throws IOException {
@@ -36,10 +41,10 @@ public class BotUtils {
     }
 
     public static <R> R fromJson(String jsonString, Class<R> resClass) {
-        return gson.fromJson(jsonString,resClass);
+        return GSON.fromJson(jsonString,resClass);
     }
 
     public static String toJson(Object obj) {
-        return gson.toJson(obj);
+        return GSON.toJson(obj);
     }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/TelegramBot.java
+++ b/library/src/main/java/com/pengrad/telegrambot/TelegramBot.java
@@ -8,6 +8,7 @@ import com.pengrad.telegrambot.model.File;
 import com.pengrad.telegrambot.request.BaseRequest;
 import com.pengrad.telegrambot.request.GetUpdates;
 import com.pengrad.telegrambot.response.BaseResponse;
+import com.pengrad.telegrambot.utility.BotUtils;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;

--- a/library/src/main/java/com/pengrad/telegrambot/TelegramBot.java
+++ b/library/src/main/java/com/pengrad/telegrambot/TelegramBot.java
@@ -166,7 +166,7 @@ public class TelegramBot {
         }
 
         private static Gson gson() {
-            return new Gson();
+            return BotUtils.GSON;
         }
 
         private static String apiUrl(String apiUrl, String botToken, boolean useTestServer) {

--- a/library/src/main/java/com/pengrad/telegrambot/model/Chat.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Chat.java
@@ -1,6 +1,8 @@
 package com.pengrad.telegrambot.model;
 
 import com.google.gson.annotations.SerializedName;
+import com.pengrad.telegrambot.model.reaction.ReactionType;
+
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -33,6 +35,7 @@ public class Chat implements Serializable {
     private Boolean is_forum;
     private ChatPhoto photo;
     private String[] active_usernames;
+    private ReactionType[] available_reactions;
     private String emoji_status_custom_emoji_id;
     private Integer emoji_status_expiration_date;
     private String bio;
@@ -89,7 +92,7 @@ public class Chat implements Serializable {
     /**
      * @deprecated Use activeUsernames() instead
      */
-    @Deprecated 
+    @Deprecated
     public String[] getActiveUsernames() {
         return active_usernames;
     }
@@ -98,10 +101,14 @@ public class Chat implements Serializable {
         return active_usernames;
     }
 
+    @Deprecated
+    public ReactionType[] availableReactions() {
+        return available_reactions;
+    }
+
     /**
      * @deprecated Use emojiStatusCustomEmojiId() instead
      */
-    @Deprecated 
     public String getEmojiStatusCustomEmojiId() {
         return emoji_status_custom_emoji_id;
     }
@@ -200,6 +207,7 @@ public class Chat implements Serializable {
                 Objects.equals(title, chat.title) &&
                 Objects.equals(photo, chat.photo) &&
                 Arrays.equals(active_usernames, chat.active_usernames) &&
+                Arrays.equals(available_reactions, chat.available_reactions) &&
                 Objects.equals(emoji_status_custom_emoji_id, chat.emoji_status_custom_emoji_id) &&
                 Objects.equals(emoji_status_expiration_date, chat.emoji_status_expiration_date) &&
                 Objects.equals(bio, chat.bio) &&
@@ -239,6 +247,7 @@ public class Chat implements Serializable {
                 ", title='" + title + '\'' +
                 ", photo=" + photo +
                 ", active_usernames=" + Arrays.toString(active_usernames) +
+                ", available_reactions=" + Arrays.toString(available_reactions) +
                 ", emoji_status_custom_emoji_id='" + emoji_status_custom_emoji_id + '\'' +
                 ", emoji_status_expiration_date='" + emoji_status_expiration_date + '\'' +
                 ", bio='" + bio + '\'' +

--- a/library/src/main/java/com/pengrad/telegrambot/model/MessageReactionCountUpdated.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/MessageReactionCountUpdated.java
@@ -1,0 +1,58 @@
+package com.pengrad.telegrambot.model;
+
+import com.pengrad.telegrambot.model.reaction.ReactionCount;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class MessageReactionCountUpdated {
+
+    private Chat chat;
+    private Integer message_id;
+    private Integer date;
+    private ReactionCount[] reactions;
+
+    public Chat chat() {
+        return chat;
+    }
+
+    public Integer messageId() {
+        return message_id;
+    }
+
+    public Integer date() {
+        return date;
+    }
+
+    public ReactionCount[] reactions() {
+        return reactions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MessageReactionCountUpdated that = (MessageReactionCountUpdated) o;
+        return Objects.equals(chat, that.chat) &&
+                Objects.equals(message_id, that.message_id) &&
+                Objects.equals(date, that.date) &&
+                Arrays.equals(reactions, that.reactions);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(chat, message_id, date);
+        result = 31 * result + Arrays.hashCode(reactions);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "MessageReactionCountUpdated{" +
+            "chat=" + chat +
+            ", message_id=" + message_id +
+            ", date=" + date +
+            ", reactions=" + Arrays.toString(reactions) +
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/MessageReactionUpdated.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/MessageReactionUpdated.java
@@ -1,0 +1,80 @@
+package com.pengrad.telegrambot.model;
+
+import com.pengrad.telegrambot.model.reaction.ReactionType;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class MessageReactionUpdated {
+
+    private Chat chat;
+    private Integer message_id;
+    private User user;
+    private Chat actor_chat;
+    private Integer date;
+    private ReactionType[] old_reaction;
+    private ReactionType[] new_reaction;
+
+    public Chat chat() {
+        return chat;
+    }
+
+    public Integer messageId() {
+        return message_id;
+    }
+
+    public User user() {
+        return user;
+    }
+
+    public Chat actorChat() {
+        return actor_chat;
+    }
+
+    public Integer date() {
+        return date;
+    }
+
+    public ReactionType[] oldReaction() {
+        return old_reaction;
+    }
+
+    public ReactionType[] newReaction() {
+        return new_reaction;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MessageReactionUpdated that = (MessageReactionUpdated) o;
+        return Objects.equals(chat, that.chat) &&
+                Objects.equals(message_id, that.message_id) &&
+                Objects.equals(user, that.user) &&
+                Objects.equals(actor_chat, that.actor_chat) &&
+                Objects.equals(date, that.date) &&
+                Arrays.equals(old_reaction, that.old_reaction) &&
+                Arrays.equals(new_reaction, that.new_reaction);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(chat, message_id, user, actor_chat, date);
+        result = 31 * result + Arrays.hashCode(old_reaction);
+        result = 31 * result + Arrays.hashCode(new_reaction);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "MessageReactionUpdated{" +
+            "chat=" + chat +
+            ", message_id=" + message_id +
+            ", user=" + user +
+            ", actor_chat=" + actor_chat +
+            ", date=" + date +
+            ", old_reaction=" + Arrays.toString(old_reaction) +
+            ", new_reaction=" + Arrays.toString(new_reaction) +
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/Update.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Update.java
@@ -25,6 +25,8 @@ public class Update implements Serializable {
     private ChatMemberUpdated my_chat_member;
     private ChatMemberUpdated chat_member;
     private ChatJoinRequest chat_join_request;
+    private MessageReactionUpdated message_reaction;
+    private MessageReactionCountUpdated message_reaction_count;
 
     public Integer updateId() {
         return update_id;
@@ -86,6 +88,14 @@ public class Update implements Serializable {
         return chat_join_request;
     }
 
+    public MessageReactionUpdated messageReaction() {
+        return message_reaction;
+    }
+
+    public MessageReactionCountUpdated messageReactionCount() {
+        return message_reaction_count;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -105,7 +115,9 @@ public class Update implements Serializable {
                 Objects.equals(poll_answer, update.poll_answer) &&
                 Objects.equals(my_chat_member, update.my_chat_member) &&
                 Objects.equals(chat_member, update.chat_member) &&
-                Objects.equals(chat_join_request, update.chat_join_request);
+                Objects.equals(chat_join_request, update.chat_join_request) &&
+                Objects.equals(message_reaction, update.message_reaction) &&
+                Objects.equals(message_reaction_count, update.message_reaction_count);
     }
 
     @Override
@@ -131,6 +143,8 @@ public class Update implements Serializable {
                 ", my_chat_member=" + my_chat_member +
                 ", chat_member=" + chat_member +
                 ", chat_join_request=" + chat_join_request +
+                ", message_reaction=" + message_reaction +
+                ", message_reaction_count=" + message_reaction_count +
                 '}';
     }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionCount.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionCount.java
@@ -1,0 +1,39 @@
+package com.pengrad.telegrambot.model.reaction;
+
+import java.util.Objects;
+
+public class ReactionCount {
+
+    private ReactionType type;
+    private Integer total_count;
+
+    public ReactionType type() {
+        return type;
+    }
+
+    public Integer totalCount() {
+        return total_count;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReactionCount that = (ReactionCount) o;
+        return Objects.equals(type, that.type) &&
+                Objects.equals(total_count, that.total_count);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, total_count);
+    }
+
+    @Override
+    public String toString() {
+        return "ReactionCount{" +
+            "type=" + type +
+            ", total_count=" + total_count +
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionType.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionType.java
@@ -1,0 +1,36 @@
+package com.pengrad.telegrambot.model.reaction;
+
+import java.util.Objects;
+
+public abstract class ReactionType {
+
+    private final String type;
+
+    public ReactionType(String type) {
+        this.type = type;
+    }
+
+    public String type() {
+        return type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReactionType that = (ReactionType) o;
+        return Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type);
+    }
+
+    @Override
+    public String toString() {
+        return "ReactionType{" +
+            "type='" + type + '\'' +
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionTypeCustomEmoji.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionTypeCustomEmoji.java
@@ -1,0 +1,44 @@
+package com.pengrad.telegrambot.model.reaction;
+
+import java.util.Objects;
+
+public class ReactionTypeCustomEmoji extends ReactionType {
+
+    public static final String CUSTOM_EMOJI_TYPE = "custom_emoji";
+
+    private String custom_emoji_id;
+
+    public ReactionTypeCustomEmoji(String customEmojiId) {
+        super(CUSTOM_EMOJI_TYPE);
+        this.custom_emoji_id = customEmojiId;
+    }
+
+    public String customEmojiId() {
+        return custom_emoji_id;
+    }
+
+    public void customEmojiId(String customEmojiId) {
+        this.custom_emoji_id = customEmojiId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReactionTypeCustomEmoji that = (ReactionTypeCustomEmoji) o;
+        return Objects.equals(custom_emoji_id, that.custom_emoji_id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(custom_emoji_id);
+    }
+
+    @Override
+    public String toString() {
+        return "ReactionTypeCustomEmoji{" +
+            "type='" + type() + '\'' +
+            "custom_emoji_id='" + custom_emoji_id + '\'' +
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionTypeEmoji.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionTypeEmoji.java
@@ -1,0 +1,44 @@
+package com.pengrad.telegrambot.model.reaction;
+
+import java.util.Objects;
+
+public class ReactionTypeEmoji extends ReactionType {
+
+    public static final String EMOJI_TYPE = "emoji";
+
+    private String emoji;
+
+    public ReactionTypeEmoji(String emoji) {
+        super(EMOJI_TYPE);
+        this.emoji = emoji;
+    }
+
+    public String emoji() {
+        return emoji;
+    }
+
+    public void emoji(String emoji) {
+        this.emoji = emoji;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReactionTypeEmoji that = (ReactionTypeEmoji) o;
+        return Objects.equals(emoji, that.emoji);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(emoji);
+    }
+
+    @Override
+    public String toString() {
+        return "ReactionTypeEmoji{" +
+            "type='" + type() + '\'' +
+            "emoji='" + emoji + '\'' +
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/BaseRequest.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/BaseRequest.java
@@ -1,6 +1,6 @@
 package com.pengrad.telegrambot.request;
 
-import com.pengrad.telegrambot.BotUtils;
+import com.pengrad.telegrambot.utility.BotUtils;
 import com.pengrad.telegrambot.response.BaseResponse;
 
 import java.util.LinkedHashMap;

--- a/library/src/main/java/com/pengrad/telegrambot/request/SetMessageReaction.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SetMessageReaction.java
@@ -1,0 +1,21 @@
+package com.pengrad.telegrambot.request;
+
+import com.pengrad.telegrambot.model.reaction.ReactionType;
+import com.pengrad.telegrambot.response.BaseResponse;
+
+public class SetMessageReaction extends BaseRequest<SetMessageReaction, BaseResponse> {
+
+    public SetMessageReaction(Object chatId, int messageId, ReactionType... reactions) {
+        super(BaseResponse.class);
+        add("chat_id", chatId).add("message_id", messageId).add("reaction", reactions);
+    }
+
+    public SetMessageReaction(Object chatId, int messageId) {
+        super(BaseResponse.class);
+        add("chat_id", chatId).add("message_id", messageId);
+    }
+
+    public SetMessageReaction isBig(boolean isBig) {
+        return add("is_big", isBig);
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/utility/BotUtils.java
+++ b/library/src/main/java/com/pengrad/telegrambot/utility/BotUtils.java
@@ -1,4 +1,4 @@
-package com.pengrad.telegrambot;
+package com.pengrad.telegrambot.utility;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/library/src/main/java/com/pengrad/telegrambot/utility/gson/ReactionTypeAdapter.java
+++ b/library/src/main/java/com/pengrad/telegrambot/utility/gson/ReactionTypeAdapter.java
@@ -1,0 +1,25 @@
+package com.pengrad.telegrambot.utility.gson;
+
+import com.google.gson.*;
+import com.pengrad.telegrambot.model.reaction.ReactionType;
+import com.pengrad.telegrambot.model.reaction.ReactionTypeCustomEmoji;
+import com.pengrad.telegrambot.model.reaction.ReactionTypeEmoji;
+
+import java.lang.reflect.Type;
+
+public class ReactionTypeAdapter implements JsonDeserializer<ReactionType> {
+
+    @Override
+    public ReactionType deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException {
+        JsonObject object = element.getAsJsonObject();
+        String discriminator = object.getAsJsonPrimitive("type").getAsString();
+
+        if (ReactionTypeEmoji.EMOJI_TYPE.equals(discriminator)) {
+            return context.deserialize(object, ReactionTypeEmoji.class);
+        } else if (ReactionTypeCustomEmoji.CUSTOM_EMOJI_TYPE.equals(discriminator)) {
+            return context.deserialize(object, ReactionTypeCustomEmoji.class);
+        }
+
+        throw new JsonParseException("Unknown ReactionType type: " + discriminator);
+    }
+}

--- a/library/src/test/java/com/pengrad/telegrambot/BotUtilsTest.java
+++ b/library/src/test/java/com/pengrad/telegrambot/BotUtilsTest.java
@@ -2,6 +2,7 @@ package com.pengrad.telegrambot;
 
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.response.SendResponse;
+import com.pengrad.telegrambot.utility.BotUtils;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;

--- a/library/src/test/java/com/pengrad/telegrambot/PaymentsTest.java
+++ b/library/src/test/java/com/pengrad/telegrambot/PaymentsTest.java
@@ -6,6 +6,7 @@ import com.pengrad.telegrambot.model.request.*;
 import com.pengrad.telegrambot.request.*;
 import com.pengrad.telegrambot.response.*;
 
+import com.pengrad.telegrambot.utility.BotUtils;
 import org.junit.*;
 
 import static com.pengrad.telegrambot.TelegramBotTest.getProp;

--- a/library/src/test/java/com/pengrad/telegrambot/TelegramBotTest.java
+++ b/library/src/test/java/com/pengrad/telegrambot/TelegramBotTest.java
@@ -8,6 +8,7 @@ import com.pengrad.telegrambot.model.request.*;
 import com.pengrad.telegrambot.passport.*;
 import com.pengrad.telegrambot.request.*;
 import com.pengrad.telegrambot.response.*;
+import com.pengrad.telegrambot.utility.BotUtils;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.pengrad</groupId>
   <artifactId>java-telegram-bot-api</artifactId>
-  <version>6.9.1</version>
+  <version>7.0.0</version>
   <name>JavaTelegramBotApi</name>
   <description>Java API for Telegram Bot API</description>
   <url>https://github.com/pengrad/java-telegram-bot-api/</url>

--- a/sample/src/main/java/com/pengrad/telegrambot/sample/spark/BotHandler.java
+++ b/sample/src/main/java/com/pengrad/telegrambot/sample/spark/BotHandler.java
@@ -1,6 +1,6 @@
 package com.pengrad.telegrambot.sample.spark;
 
-import com.pengrad.telegrambot.BotUtils;
+import com.pengrad.telegrambot.utility.BotUtils;
 import com.pengrad.telegrambot.TelegramBot;
 import com.pengrad.telegrambot.model.Message;
 import com.pengrad.telegrambot.model.Update;


### PR DESCRIPTION
This pull request implements Reactions part of Bot API 7.0 update:

**Reactions**

- Added the classes [ReactionTypeEmoji](https://core.telegram.org/bots/api#reactiontypeemoji) and [ReactionTypeCustomEmoji](https://core.telegram.org/bots/api#reactiontypecustomemoji) representing different types of reaction.
- Added updates about a reaction change on a message with non-anonymous reactions, represented by the class [MessageReactionUpdated](https://core.telegram.org/bots/api#messagereactionupdated) and the field message_reaction in the class [Update](https://core.telegram.org/bots/api#update). The bot must explicitly allow the update to receive it.
- Added updates about reaction changes on a message with anonymous reactions, represented by the class [MessageReactionCountUpdated](https://core.telegram.org/bots/api#messagereactioncountupdated) and the field message_reaction_count in the class [Update](https://core.telegram.org/bots/api#update). The bot must explicitly allow the update to receive it.
- Added the method [setMessageReaction](https://core.telegram.org/bots/api#setmessagereaction) that allows bots to react to messages.
- Added the field available_reactions to the class [Chat](https://core.telegram.org/bots/api#chat).

Changes:
- Add **SetMessageReaction** request [see setMessageReaction](https://core.telegram.org/bots/api#setmessagereaction)
- Add **message_reaction** and **message_reaction_count** updates to Update [see Update](https://core.telegram.org/bots/api#update)
- Add **available_reactions** field to Chat [see Chat](https://core.telegram.org/bots/api#chat)
- Add **ReactionTypeAdapter** because of requirement to use discriminator field in ReactionType and use BotUtils#GSON in TelegramBotClient
- Move BotUtils to **com.pengrad.telegrambot.utility** package