### PR TITLE
Implement Bot API 7.0 Giveaways

### DIFF
--- a/library/src/main/java/com/pengrad/telegrambot/model/Message.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Message.java
@@ -1,5 +1,9 @@
 package com.pengrad.telegrambot.model;
 
+import com.pengrad.telegrambot.model.giveaway.Giveaway;
+import com.pengrad.telegrambot.model.giveaway.GiveawayCompleted;
+import com.pengrad.telegrambot.model.giveaway.GiveawayCreated;
+import com.pengrad.telegrambot.model.giveaway.GiveawayWinners;
 import com.pengrad.telegrambot.model.request.InlineKeyboardMarkup;
 import com.pengrad.telegrambot.passport.PassportData;
 
@@ -79,6 +83,10 @@ public class Message implements Serializable {
     private ForumTopicReopened forum_topic_reopened;
     private GeneralForumTopicHidden general_forum_topic_hidden;
     private GeneralForumTopicUnhidden general_forum_topic_unhidden;
+    private GiveawayCreated giveaway_created;
+    private Giveaway giveaway;
+    private GiveawayWinners giveaway_winners;
+    private GiveawayCompleted giveaway_completed;
     private WriteAccessAllowed write_access_allowed;
 
     private VideoChatStarted video_chat_started;
@@ -447,6 +455,10 @@ public class Message implements Serializable {
                 Objects.equals(forum_topic_reopened, message.forum_topic_reopened) &&
                 Objects.equals(general_forum_topic_hidden, message.general_forum_topic_hidden) &&
                 Objects.equals(general_forum_topic_unhidden, message.general_forum_topic_unhidden) &&
+                Objects.equals(giveaway_created, message.giveaway_created) &&
+                Objects.equals(giveaway, message.giveaway) &&
+                Objects.equals(giveaway_winners, message.giveaway_winners) &&
+                Objects.equals(giveaway_completed, message.giveaway_completed) &&
                 Objects.equals(write_access_allowed, message.write_access_allowed) &&
                 Objects.equals(video_chat_started, message.video_chat_started) &&
                 Objects.equals(video_chat_ended, message.video_chat_ended) &&
@@ -529,6 +541,10 @@ public class Message implements Serializable {
                 ", forum_topic_reopened=" + forum_topic_reopened +
                 ", general_forum_topic_hidden=" + general_forum_topic_hidden +
                 ", general_forum_topic_unhidden=" + general_forum_topic_unhidden +
+                ", giveaway_created=" + giveaway_created +
+                ", giveaway=" + giveaway +
+                ", giveaway_winners=" + giveaway_winners +
+                ", giveaway_completed=" + giveaway_completed +
                 ", write_access_allowed=" + write_access_allowed +
                 ", video_chat_started=" + video_chat_started +
                 ", video_chat_ended=" + video_chat_ended +

--- a/library/src/main/java/com/pengrad/telegrambot/model/giveaway/Giveaway.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/giveaway/Giveaway.java
@@ -1,0 +1,87 @@
+package com.pengrad.telegrambot.model.giveaway;
+
+import com.pengrad.telegrambot.model.Chat;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class Giveaway {
+
+    private Chat[] chats;
+    private Integer winners_selection_date;
+    private Integer winner_count;
+    private Boolean only_new_members;
+    private Boolean has_public_winners;
+    private String prize_description;
+    private String[] country_codes;
+    private Integer premium_subscription_month_count;
+
+    public Chat[] chats() {
+        return chats;
+    }
+
+    public Integer winnersSelectionDate() {
+        return winners_selection_date;
+    }
+
+    public Integer winnerCount() {
+        return winner_count;
+    }
+
+    public Boolean onlyNewMembers() {
+        return only_new_members;
+    }
+
+    public Boolean hasPublicWinners() {
+        return has_public_winners;
+    }
+
+    public String prizeDescription() {
+        return prize_description;
+    }
+
+    public String[] countryCodes() {
+        return country_codes;
+    }
+
+    public Integer premiumSubscriptionMonthCount() {
+        return premium_subscription_month_count;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Giveaway giveaway = (Giveaway) o;
+        return Arrays.equals(chats, giveaway.chats) &&
+                Objects.equals(winners_selection_date, giveaway.winners_selection_date) &&
+                Objects.equals(winner_count, giveaway.winner_count) &&
+                Objects.equals(only_new_members, giveaway.only_new_members) &&
+                Objects.equals(has_public_winners, giveaway.has_public_winners) &&
+                Objects.equals(prize_description, giveaway.prize_description) &&
+                Arrays.equals(country_codes, giveaway.country_codes) &&
+                Objects.equals(premium_subscription_month_count, giveaway.premium_subscription_month_count);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(winners_selection_date, winner_count, only_new_members, has_public_winners, prize_description, premium_subscription_month_count);
+        result = 31 * result + Arrays.hashCode(chats);
+        result = 31 * result + Arrays.hashCode(country_codes);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Giveaway{" +
+            "chats=" + Arrays.toString(chats) +
+            ", winners_selection_date=" + winners_selection_date +
+            ", winner_count=" + winner_count +
+            ", only_new_members=" + only_new_members +
+            ", has_public_winners=" + has_public_winners +
+            ", prize_description='" + prize_description + '\'' +
+            ", country_codes=" + Arrays.toString(country_codes) +
+            ", premium_subscription_month_count=" + premium_subscription_month_count +
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/giveaway/GiveawayCompleted.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/giveaway/GiveawayCompleted.java
@@ -1,0 +1,48 @@
+package com.pengrad.telegrambot.model.giveaway;
+
+import com.pengrad.telegrambot.model.Message;
+
+import java.util.Objects;
+
+public class GiveawayCompleted {
+
+    private Integer winner_count;
+    private Integer unclaimed_prize_count;
+    private Message giveaway_message;
+
+    public Integer winnerCount() {
+        return winner_count;
+    }
+
+    public Integer unclaimedPrizeCount() {
+        return unclaimed_prize_count;
+    }
+
+    public Message giveawayMessage() {
+        return giveaway_message;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GiveawayCompleted that = (GiveawayCompleted) o;
+        return Objects.equals(winner_count, that.winner_count) &&
+                Objects.equals(unclaimed_prize_count, that.unclaimed_prize_count) &&
+                Objects.equals(giveaway_message, that.giveaway_message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(winner_count, unclaimed_prize_count, giveaway_message);
+    }
+
+    @Override
+    public String toString() {
+        return "GiveawayCompleted{" +
+            "winner_count=" + winner_count +
+            ", unclaimed_prize_count=" + unclaimed_prize_count +
+            ", giveaway_message=" + giveaway_message +
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/giveaway/GiveawayCreated.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/giveaway/GiveawayCreated.java
@@ -1,0 +1,9 @@
+package com.pengrad.telegrambot.model.giveaway;
+
+public class GiveawayCreated {
+
+    @Override
+    public String toString() {
+        return "GiveawayCreated{}";
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/giveaway/GiveawayWinners.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/giveaway/GiveawayWinners.java
@@ -1,0 +1,108 @@
+package com.pengrad.telegrambot.model.giveaway;
+
+import com.pengrad.telegrambot.model.Chat;
+import com.pengrad.telegrambot.model.User;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class GiveawayWinners {
+
+    private Chat chat;
+    private Integer giveaway_message_id;
+    private Integer winners_selection_date;
+    private Integer winner_count;
+    private User[] winners;
+    private Integer additional_chat_count;
+    private Integer premium_subscription_month_count;
+    private Integer unclaimed_prize_count;
+    private Boolean only_new_members;
+    private Boolean was_refunded;
+    private String prize_description;
+
+    public Chat chat() {
+        return chat;
+    }
+
+    public Integer giveawayMessageId() {
+        return giveaway_message_id;
+    }
+
+    public Integer winnersSelectionDate() {
+        return winners_selection_date;
+    }
+
+    public Integer winnerCount() {
+        return winner_count;
+    }
+
+    public User[] winners() {
+        return winners;
+    }
+
+    public Integer additionalChatCount() {
+        return additional_chat_count;
+    }
+
+    public Integer premiumSubscriptionMonthCount() {
+        return premium_subscription_month_count;
+    }
+
+    public Integer unclaimedPrizeCount() {
+        return unclaimed_prize_count;
+    }
+
+    public Boolean onlyNewMembers() {
+        return only_new_members;
+    }
+
+    public Boolean wasRefunded() {
+        return was_refunded;
+    }
+
+    public String prizeDescription() {
+        return prize_description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GiveawayWinners that = (GiveawayWinners) o;
+        return Objects.equals(chat, that.chat) &&
+                Objects.equals(giveaway_message_id, that.giveaway_message_id) &&
+                Objects.equals(winners_selection_date, that.winners_selection_date) &&
+                Objects.equals(winner_count, that.winner_count) &&
+                Arrays.equals(winners, that.winners) &&
+                Objects.equals(additional_chat_count, that.additional_chat_count) &&
+                Objects.equals(premium_subscription_month_count, that.premium_subscription_month_count) &&
+                Objects.equals(unclaimed_prize_count, that.unclaimed_prize_count) &&
+                Objects.equals(only_new_members, that.only_new_members) &&
+                Objects.equals(was_refunded, that.was_refunded) &&
+                Objects.equals(prize_description, that.prize_description);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(chat, giveaway_message_id, winners_selection_date, winner_count, additional_chat_count, premium_subscription_month_count, unclaimed_prize_count, only_new_members, was_refunded, prize_description);
+        result = 31 * result + Arrays.hashCode(winners);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "GiveawayWinners{" +
+            "chat=" + chat +
+            ", giveaway_message_id=" + giveaway_message_id +
+            ", winners_selection_date=" + winners_selection_date +
+            ", winner_count=" + winner_count +
+            ", winners=" + Arrays.toString(winners) +
+            ", additional_chat_count=" + additional_chat_count +
+            ", premium_subscription_month_count=" + premium_subscription_month_count +
+            ", unclaimed_prize_count=" + unclaimed_prize_count +
+            ", only_new_members=" + only_new_members +
+            ", was_refunded=" + was_refunded +
+            ", prize_description='" + prize_description + '\'' +
+            '}';
+    }
+}


### PR DESCRIPTION
This pull request implements Giveaway part of Bot API 7.0 update:

**Giveaway**

- Added the class [Giveaway](https://core.telegram.org/bots/api#giveaway) and the field giveaway to the class [Message](https://core.telegram.org/bots/api#message) for messages about scheduled giveaways.
- Added the class [GiveawayCreated](https://core.telegram.org/bots/api#giveawaycreated) and the field giveaway_created to the class [Message](https://core.telegram.org/bots/api#message) for service messages about the creation of a scheduled giveaway.
- Added the class [GiveawayWinners](https://core.telegram.org/bots/api#giveawaywinners) and the field giveaway_winners to the class [Message](https://core.telegram.org/bots/api#message) for messages about the completion of a giveaway with public winners.
- Added the class [GiveawayCompleted](https://core.telegram.org/bots/api#giveawaycompleted) and the field giveaway_completed to the class [Message](https://core.telegram.org/bots/api#message) for service messages about the completion of a giveaway without public winners.

Changes:
Add **giveaway_created**, **giveaway**, **giveaway_winners** and **giveaway_completed** to Message [see Message](https://core.telegram.org/bots/api#message)