### PR TITLE
Add setters to LinkPreviewOptions & open Message#forwardOrigin

### DIFF
--- a/library/src/main/java/com/pengrad/telegrambot/model/LinkPreviewOptions.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/LinkPreviewOptions.java
@@ -14,27 +14,50 @@ public class LinkPreviewOptions implements Serializable {
     private Boolean prefer_large_media;
     private Boolean show_above_text;
 
-
     public Boolean isDisabled() {
         return is_disabled;
+    }
+
+    public LinkPreviewOptions isDisabled(boolean isDisabled) {
+        this.is_disabled = isDisabled;
+        return this;
     }
 
     public String url() {
         return url;
     }
 
+    public LinkPreviewOptions url(String url) {
+        this.url = url;
+        return this;
+    }
+
     public Boolean preferSmallMedia() {
         return prefer_small_media;
+    }
+
+    public LinkPreviewOptions preferSmallMedia(Boolean preferSmallMedia) {
+        this.prefer_small_media = preferSmallMedia;
+        return this;
     }
 
     public Boolean preferLargeMedia() {
         return prefer_large_media;
     }
 
+    public LinkPreviewOptions preferLargeMedia(Boolean preferLargeMedia) {
+        this.prefer_large_media = preferLargeMedia;
+        return this;
+    }
+
     public Boolean showAboveText() {
         return show_above_text;
     }
 
+    public LinkPreviewOptions showAboveText(Boolean showAboveText) {
+        this.show_above_text = showAboveText;
+        return this;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/library/src/main/java/com/pengrad/telegrambot/model/Message.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Message.java
@@ -98,7 +98,7 @@ public class Message extends MaybeInaccessibleMessage implements Serializable {
         return sender_chat;
     }
 
-    private MessageOrigin forwardOrigin() {
+    public MessageOrigin forwardOrigin() {
         return forward_origin;
     }
 


### PR DESCRIPTION
There is unable to configure preview options in `sendMessage` method because `LinkPreviewOptions` doesn't have any setters
Issue: https://github.com/pengrad/java-telegram-bot-api/issues/361