### PR TITLE
Fix ModelTest: remove story field from EqualsVerifier ignore

### DIFF
--- a/library/src/test/java/com/pengrad/telegrambot/ModelTest.java
+++ b/library/src/test/java/com/pengrad/telegrambot/ModelTest.java
@@ -87,10 +87,6 @@ public class ModelTest {
                 verifierApi.withIgnoredFields("forum_topic_reopened");
                 verifierApi.withIgnoredFields("general_forum_topic_hidden");
                 verifierApi.withIgnoredFields("general_forum_topic_unhidden");
-                verifierApi.withIgnoredFields("story");
-            }
-            if (c == ExternalReplyInfo.class) {
-                verifierApi.withIgnoredFields("story");
             }
 
             verifierApi.verify();


### PR DESCRIPTION
Story class now has implemented equals and hashCode methods so it shouldn't be ignored anymore