### PR TITLE
Open CallbackQuery#maybeInaccessibleMessage

### DIFF
--- a/library/src/main/java/com/pengrad/telegrambot/model/CallbackQuery.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/CallbackQuery.java
@@ -27,7 +27,7 @@ public class CallbackQuery implements Serializable {
         return from;
     }
 
-    private MaybeInaccessibleMessage maybeInaccessibleMessage() {
+    public MaybeInaccessibleMessage maybeInaccessibleMessage() {
         return message;
     }
 


### PR DESCRIPTION
There is unable to get a message with modern method because of `CallbackQuery#maybeInaccessibleMessage` is private