### PR TITLE
fix int in shared_users json serialization

### DIFF
--- a/library/src/main/java/com/pengrad/telegrambot/model/UsersShared.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/UsersShared.java
@@ -10,7 +10,7 @@ public class UsersShared implements Serializable {
     private final static long serialVersionUID = 0L;
 
     private Integer request_id;
-    private Integer[] user_ids;
+    private Long[] user_ids;
     private SharedUser[] users;
 
     public Integer requestId() {
@@ -25,7 +25,7 @@ public class UsersShared implements Serializable {
      * @deprecated Use {@link UsersShared#users()} instead
      */
     @Deprecated
-    public Integer[] userIds() {
+    public Long[] userIds() {
         return user_ids;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/shared/SharedUser.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/shared/SharedUser.java
@@ -10,13 +10,13 @@ public class SharedUser implements Serializable {
 
     private final static long serialVersionUID = 0L;
 
-    private Integer user_id;
+    private Long user_id;
     private String first_name;
     private String last_name;
     private String username;
     private PhotoSize[] photo;
 
-    public Integer userId() {
+    public Long userId() {
         return user_id;
     }
 

--- a/library/src/test/java/com/pengrad/telegrambot/BotUtilsTest.java
+++ b/library/src/test/java/com/pengrad/telegrambot/BotUtilsTest.java
@@ -20,11 +20,12 @@ import static org.junit.Assert.assertNull;
 public class BotUtilsTest {
 
     final String updateStr = "{\"update_id\":874199391,\n" +
-            "\"message\":{\"message_id\":33111,\"from\":{\"id\":1231231231,\"is_bot\":false,\"first_name\":\"RRRR\",\"username\":\"RRRR54321\"},\"chat\":{\"id\":-23123123123123,\"title\":\"hhh iiiiii ccccc\",\"type\":\"supergroup\"},\"date\":1579958705,\"text\":\"block the news\"}}";
+            "\"message\":{\"message_id\":33111,\"from\":{\"id\":1231231231,\"is_bot\":false,\"first_name\":\"RRRR\",\"username\":\"RRRR54321\"},\"chat\":{\"id\":-23123123123123,\"title\":\"hhh iiiiii ccccc\",\"type\":\"supergroup\"},\"user_shared\":{\"user_id\":6111111111,\"request_id\":1},\"users_shared\":{\"user_ids\":[6111111111],\"users\":[{\"user_id\":6111111111,\"first_name\":\"FirstNameTest\",\"last_name\":\"LastNameTest\"}],\"request_id\":1},\"date\":1579958705,\"text\":\"block the news\"}}";
 
     private void check(Update update) {
         assertEquals(update.updateId(), Integer.valueOf(874199391));
         assertEquals(update.message().messageId(), Integer.valueOf(33111));
+        assertEquals(update.message().usersShared().users()[0].userId(), Long.valueOf(6111111111L));
     }
 
     @Test
@@ -51,5 +52,4 @@ public class BotUtilsTest {
         assertNull(BotUtils.fromJson(null, SendResponse.class));
         assertNull(BotUtils.fromJson("",SendResponse.class));
     }
-
 }


### PR DESCRIPTION
Fix for NumberFormatException
com.google.gson.JsonSyntaxException: java.lang.NumberFormatException: Expected an int but was 6111111111 at line 2 column 392 path $.result[0].message.users_shared.user_ids[0]
at com.recomendo.recomendo.telegram.bot.BotClient.readMessages(BotClient.java:25)