### PR TITLE
BOT API v7.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ private.key
 .project
 library/.classpath
 sample/.classpath
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Java library for interacting with [Telegram Bot API](https://core.telegram.org/b
 
 Gradle:
 ```groovy
-implementation 'com.github.pengrad:java-telegram-bot-api:7.2.1'
+implementation 'com.github.pengrad:java-telegram-bot-api:7.4.0'
 ```
 Maven:
 ```xml
 <dependency>
   <groupId>com.github.pengrad</groupId>
   <artifactId>java-telegram-bot-api</artifactId>
-  <version>7.2.1</version>
+  <version>7.4.0</version>
 </dependency>
 ```
 [JAR with all dependencies on release page](https://github.com/pengrad/java-telegram-bot-api/releases)

--- a/README_RU.md
+++ b/README_RU.md
@@ -13,14 +13,14 @@ Java библиотека, созданная для работы с [Telegram B
 
 Gradle:
 ```groovy
-implementation 'com.github.pengrad:java-telegram-bot-api:7.2.1'
+implementation 'com.github.pengrad:java-telegram-bot-api:7.4.0'
 ```
 Maven:
 ```xml
 <dependency>
   <groupId>com.github.pengrad</groupId>
   <artifactId>java-telegram-bot-api</artifactId>
-  <version>7.2.1</version>
+  <version>7.4.0</version>
 </dependency>
 ```
 Также JAR со всеми зависимостями можно найти [в релизах](https://github.com/pengrad/java-telegram-bot-api/releases).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.github.pengrad
-VERSION_NAME=7.2.1
+VERSION_NAME=7.4.0
 
 POM_DESCRIPTION=Java API for Telegram Bot API
 POM_URL=https://github.com/pengrad/java-telegram-bot-api/

--- a/library/src/main/java/com/pengrad/telegrambot/constants/LivePeriod.java
+++ b/library/src/main/java/com/pengrad/telegrambot/constants/LivePeriod.java
@@ -1,0 +1,7 @@
+package com.pengrad.telegrambot.constants;
+
+public class LivePeriod {
+
+    public final static Integer INFINITE_LIVE_PERIOD = Integer.MAX_VALUE;
+    
+}

--- a/library/src/main/java/com/pengrad/telegrambot/constants/LivePeriod.java
+++ b/library/src/main/java/com/pengrad/telegrambot/constants/LivePeriod.java
@@ -3,5 +3,7 @@ package com.pengrad.telegrambot.constants;
 public class LivePeriod {
 
     public final static Integer INFINITE_LIVE_PERIOD = Integer.MAX_VALUE;
+
+    private LivePeriod() { }
     
 }

--- a/library/src/main/java/com/pengrad/telegrambot/model/Chat.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Chat.java
@@ -1,14 +1,8 @@
 package com.pengrad.telegrambot.model;
 
 import com.google.gson.annotations.SerializedName;
-import com.pengrad.telegrambot.model.business.BusinessIntro;
-import com.pengrad.telegrambot.model.business.BusinessLocation;
-import com.pengrad.telegrambot.model.business.BusinessOpeningHours;
-import com.pengrad.telegrambot.model.reaction.ReactionType;
-
 
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -36,41 +30,6 @@ public class Chat implements Serializable {
     private String last_name;
 
     private Boolean is_forum;
-    private ChatPhoto photo;
-    private String[] active_usernames;
-    private Birthdate birthdate;
-    private BusinessIntro business_intro;
-    private BusinessLocation business_location;
-    private BusinessOpeningHours business_opening_hours;
-    private Chat personal_chat;
-    private ReactionType[] available_reactions;
-    private Integer accent_color_id;
-    private String background_custom_emoji_id;
-    private Integer profile_accent_color_id;
-    private String profile_background_custom_emoji_id;
-    private String emoji_status_custom_emoji_id;
-    private Integer emoji_status_expiration_date;
-    private String bio;
-    private Boolean has_private_forwards;
-    private Boolean has_restricted_voice_and_video_messages;
-    private Boolean has_hidden_members;
-    private Boolean has_aggressive_anti_spam_enabled;
-    private Boolean join_to_send_messages;
-    private Boolean join_by_request;
-    private String description;
-    private String invite_link;
-    private Message pinned_message;
-    private ChatPermissions permissions;
-    private Integer slow_mode_delay;
-    private Integer unrestrict_boost_count;
-    private Integer message_auto_delete_time;
-    private Boolean has_protected_content;
-    private Boolean has_visible_history;
-    private String sticker_set_name;
-    private Boolean can_set_sticker_set;
-    private String custom_emoji_sticker_set_name;
-    private Long linked_chat_id;
-    private ChatLocation location;
 
     public Long id() {
         return id;
@@ -100,162 +59,6 @@ public class Chat implements Serializable {
         return title;
     }
 
-    public ChatPhoto photo() {
-        return photo;
-    }
-
-    /**
-     * @deprecated Use activeUsernames() instead
-     */
-    @Deprecated
-    public String[] getActiveUsernames() {
-        return active_usernames;
-    }
-
-    public String[] activeUsernames() {
-        return active_usernames;
-    }
-
-    public Birthdate birthdate() {
-        return birthdate;
-    }
-
-    public BusinessIntro businessIntro() {
-        return business_intro;
-    }
-
-    public BusinessLocation businessLocation() {
-        return business_location;
-    }
-
-    public BusinessOpeningHours businessOpeningHours() {
-        return business_opening_hours;
-    }
-
-    public Chat personalChat() {
-        return personal_chat;
-    }
-
-    public ReactionType[] availableReactions() {
-        return available_reactions;
-    }
-
-    public Integer accentColorId() {
-        return accent_color_id;
-    }
-
-    public String backgroundCustomEmojiId() {
-        return background_custom_emoji_id;
-    }
-
-    public Integer profileAccentColorId() {
-        return profile_accent_color_id;
-    }
-
-    public String profileBackgroundCustomEmojiId() {
-        return profile_background_custom_emoji_id;
-    }
-
-    /**
-     * @deprecated Use emojiStatusCustomEmojiId() instead
-     */
-    @Deprecated
-    public String getEmojiStatusCustomEmojiId() {
-        return emoji_status_custom_emoji_id;
-    }
-
-    public String emojiStatusCustomEmojiId() {
-        return emoji_status_custom_emoji_id;
-    }
-
-    public Integer emojiStatusExpirationDate() {
-        return emoji_status_expiration_date;
-    }
-
-    public String bio() {
-        return bio;
-    }
-
-    public Boolean hasPrivateForwards() {
-        return has_private_forwards != null && has_private_forwards;
-    }
-
-    public Boolean hasRestrictedVoiceAndVideoMessages() {
-        return has_restricted_voice_and_video_messages != null && has_restricted_voice_and_video_messages;
-    }
-
-    public Boolean hasHiddenMembers() {
-        return has_hidden_members != null && has_hidden_members;
-    }
-
-    public Boolean hasAggressiveAntiSpamEnabled() {
-        return has_aggressive_anti_spam_enabled != null && has_aggressive_anti_spam_enabled;
-    }
-
-    public Boolean joinToSendMessages() {
-        return join_to_send_messages != null && join_to_send_messages;
-    }
-
-    public Boolean joinByRequest() {
-        return join_by_request != null && join_by_request;
-    }
-
-    public String description() {
-        return description;
-    }
-
-    public String inviteLink() {
-        return invite_link;
-    }
-
-    public Message pinnedMessage() {
-        return pinned_message;
-    }
-
-    public ChatPermissions permissions() {
-        return permissions;
-    }
-
-    public Integer slowModeDelay() {
-        return slow_mode_delay;
-    }
-
-    public Integer unrestrictBoostCount() {
-        return unrestrict_boost_count;
-    }
-
-    public Integer messageAutoDeleteTime() {
-        return message_auto_delete_time;
-    }
-
-    public Boolean hasProtectedContent() {
-        return has_protected_content != null && has_protected_content;
-    }
-
-    public Boolean hasVisibleHistory() {
-        return has_visible_history != null && has_visible_history;
-    }
-
-    public String stickerSetName() {
-        return sticker_set_name;
-    }
-
-    public Boolean canSetStickerSet() {
-        return can_set_sticker_set != null && can_set_sticker_set;
-    }
-
-    public String customEmojiStickerSetName() {
-        return custom_emoji_sticker_set_name;
-    }
-
-    public Long linkedChatId() {
-        return linked_chat_id;
-    }
-
-    public ChatLocation location() {
-        return location;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -267,42 +70,7 @@ public class Chat implements Serializable {
                 Objects.equals(last_name, chat.last_name) &&
                 Objects.equals(is_forum, chat.is_forum) &&
                 Objects.equals(username, chat.username) &&
-                Objects.equals(title, chat.title) &&
-                Objects.equals(photo, chat.photo) &&
-                Arrays.equals(active_usernames, chat.active_usernames) &&
-                Objects.equals(birthdate, chat.birthdate) &&
-                Objects.equals(business_intro, chat.business_intro) &&
-                Objects.equals(business_location, chat.business_location) &&
-                Objects.equals(business_opening_hours, chat.business_opening_hours) &&
-                Objects.equals(personal_chat, chat.personal_chat) &&
-                Arrays.equals(available_reactions, chat.available_reactions) &&
-                Objects.equals(accent_color_id, chat.accent_color_id) &&
-                Objects.equals(background_custom_emoji_id, chat.background_custom_emoji_id) &&
-                Objects.equals(profile_accent_color_id, chat.profile_accent_color_id) &&
-                Objects.equals(profile_background_custom_emoji_id, chat.profile_background_custom_emoji_id) &&
-                Objects.equals(emoji_status_custom_emoji_id, chat.emoji_status_custom_emoji_id) &&
-                Objects.equals(emoji_status_expiration_date, chat.emoji_status_expiration_date) &&
-                Objects.equals(bio, chat.bio) &&
-                Objects.equals(has_private_forwards, chat.has_private_forwards) &&
-                Objects.equals(has_restricted_voice_and_video_messages, chat.has_restricted_voice_and_video_messages) &&
-                Objects.equals(has_hidden_members, chat.has_hidden_members) &&
-                Objects.equals(has_aggressive_anti_spam_enabled, chat.has_aggressive_anti_spam_enabled) &&
-                Objects.equals(join_to_send_messages, chat.join_to_send_messages) &&
-                Objects.equals(join_by_request, chat.join_by_request) &&
-                Objects.equals(description, chat.description) &&
-                Objects.equals(invite_link, chat.invite_link) &&
-                Objects.equals(pinned_message, chat.pinned_message) &&
-                Objects.equals(permissions, chat.permissions) &&
-                Objects.equals(slow_mode_delay, chat.slow_mode_delay) &&
-                Objects.equals(unrestrict_boost_count, chat.unrestrict_boost_count) &&
-                Objects.equals(message_auto_delete_time, chat.message_auto_delete_time) &&
-                Objects.equals(has_protected_content, chat.has_protected_content) &&
-                Objects.equals(has_visible_history, chat.has_visible_history) &&
-                Objects.equals(sticker_set_name, chat.sticker_set_name) &&
-                Objects.equals(can_set_sticker_set, chat.can_set_sticker_set) &&
-                Objects.equals(custom_emoji_sticker_set_name, chat.custom_emoji_sticker_set_name) &&
-                Objects.equals(linked_chat_id, chat.linked_chat_id) &&
-                Objects.equals(location, chat.location);
+                Objects.equals(title, chat.title);
     }
 
     @Override
@@ -319,42 +87,7 @@ public class Chat implements Serializable {
                 ", last_name='" + last_name + '\'' +
                 ", is_forum=" + is_forum +
                 ", username='" + username + '\'' +
-                ", title='" + title + '\'' +
-                ", photo=" + photo +
-                ", active_usernames=" + Arrays.toString(active_usernames) +
-                ", birthdate=" + birthdate +
-                ", business_intro=" + business_intro +
-                ", business_location=" + business_location +
-                ", business_opening_hours=" + business_opening_hours +
-                ", personal_chat=" + personal_chat +
-                ", available_reactions=" + Arrays.toString(available_reactions) +
-                ", accent_color_id=" + accent_color_id +
-                ", background_custom_emoji_id='" + background_custom_emoji_id + '\'' +
-                ", profile_accent_color_id=" + profile_accent_color_id +
-                ", profile_background_custom_emoji_id='" + profile_background_custom_emoji_id + '\'' +
-                ", emoji_status_custom_emoji_id='" + emoji_status_custom_emoji_id + '\'' +
-                ", emoji_status_expiration_date='" + emoji_status_expiration_date + '\'' +
-                ", bio='" + bio + '\'' +
-                ", has_private_forwards=" + has_private_forwards +
-                ", has_restricted_voice_and_video_messages=" + has_restricted_voice_and_video_messages +
-                ", has_hidden_members=" + has_hidden_members +
-                ", has_aggressive_anti_spam_enabled=" + has_aggressive_anti_spam_enabled +
-                ", join_to_send_messages=" + join_to_send_messages +
-                ", join_by_request=" + join_by_request +
-                ", description='" + description + '\'' +
-                ", invite_link='" + invite_link + '\'' +
-                ", pinned_message=" + pinned_message +
-                ", permissions=" + permissions +
-                ", slow_mode_delay=" + slow_mode_delay +
-                ", unrestrict_boost_count=" + unrestrict_boost_count +
-                ", message_auto_delete_time=" + message_auto_delete_time +
-                ", has_protected_content=" + has_protected_content +
-                ", has_visible_history=" + has_visible_history +
-                ", sticker_set_name='" + sticker_set_name + '\'' +
-                ", can_set_sticker_set=" + can_set_sticker_set +
-                ", custom_emoji_sticker_set_name=" + custom_emoji_sticker_set_name +
-                ", linked_chat_id=" + linked_chat_id +
-                ", location=" + location +
+                ", title='" + title + '\'' +                
                 '}';
     }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/model/ChatFullInfo.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/ChatFullInfo.java
@@ -42,6 +42,7 @@ public class ChatFullInfo implements Serializable {
     private Chat personal_chat;
     private ReactionType[] available_reactions;
     private Integer accent_color_id;
+    private Integer max_reaction_count;
     private String background_custom_emoji_id;
     private Integer profile_accent_color_id;
     private String profile_background_custom_emoji_id;
@@ -139,6 +140,10 @@ public class ChatFullInfo implements Serializable {
 
     public Integer accentColorId() {
         return accent_color_id;
+    }
+
+    public Integer maxReactionCount() {
+        return max_reaction_count;
     }
 
     public String backgroundCustomEmojiId() {
@@ -274,6 +279,7 @@ public class ChatFullInfo implements Serializable {
                 Objects.equals(personal_chat, chat.personal_chat) &&
                 Arrays.equals(available_reactions, chat.available_reactions) &&
                 Objects.equals(accent_color_id, chat.accent_color_id) &&
+                Objects.equals(max_reaction_count, chat.max_reaction_count) &&
                 Objects.equals(background_custom_emoji_id, chat.background_custom_emoji_id) &&
                 Objects.equals(profile_accent_color_id, chat.profile_accent_color_id) &&
                 Objects.equals(profile_background_custom_emoji_id, chat.profile_background_custom_emoji_id) &&
@@ -326,6 +332,7 @@ public class ChatFullInfo implements Serializable {
                 ", personal_chat=" + personal_chat +
                 ", available_reactions=" + Arrays.toString(available_reactions) +
                 ", accent_color_id=" + accent_color_id +
+                ", max_reaction_count=" + max_reaction_count +
                 ", background_custom_emoji_id='" + background_custom_emoji_id + '\'' +
                 ", profile_accent_color_id=" + profile_accent_color_id +
                 ", profile_background_custom_emoji_id='" + profile_background_custom_emoji_id + '\'' +

--- a/library/src/main/java/com/pengrad/telegrambot/model/ChatFullInfo.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/ChatFullInfo.java
@@ -1,0 +1,357 @@
+package com.pengrad.telegrambot.model;
+
+import com.google.gson.annotations.SerializedName;
+import com.pengrad.telegrambot.model.business.BusinessIntro;
+import com.pengrad.telegrambot.model.business.BusinessLocation;
+import com.pengrad.telegrambot.model.business.BusinessOpeningHours;
+import com.pengrad.telegrambot.model.reaction.ReactionType;
+
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+
+
+public class ChatFullInfo implements Serializable {
+    private final static long serialVersionUID = 0L;
+
+    public enum Type {
+        @SerializedName("private") Private, group, supergroup, channel
+    }
+
+    private Long id;
+    private Type type;
+
+    //Channel and Group
+    private String title;
+
+    //Private and Channel
+    private String username;
+
+    //Private
+    private String first_name;
+    private String last_name;
+
+    private Boolean is_forum;
+    private ChatPhoto photo;
+    private String[] active_usernames;
+    private Birthdate birthdate;
+    private BusinessIntro business_intro;
+    private BusinessLocation business_location;
+    private BusinessOpeningHours business_opening_hours;
+    private Chat personal_chat;
+    private ReactionType[] available_reactions;
+    private Integer accent_color_id;
+    private String background_custom_emoji_id;
+    private Integer profile_accent_color_id;
+    private String profile_background_custom_emoji_id;
+    private String emoji_status_custom_emoji_id;
+    private Integer emoji_status_expiration_date;
+    private String bio;
+    private Boolean has_private_forwards;
+    private Boolean has_restricted_voice_and_video_messages;
+    private Boolean has_hidden_members;
+    private Boolean has_aggressive_anti_spam_enabled;
+    private Boolean join_to_send_messages;
+    private Boolean join_by_request;
+    private String description;
+    private String invite_link;
+    private Message pinned_message;
+    private ChatPermissions permissions;
+    private Integer slow_mode_delay;
+    private Integer unrestrict_boost_count;
+    private Integer message_auto_delete_time;
+    private Boolean has_protected_content;
+    private Boolean has_visible_history;
+    private String sticker_set_name;
+    private Boolean can_set_sticker_set;
+    private String custom_emoji_sticker_set_name;
+    private Long linked_chat_id;
+    private ChatLocation location;
+
+    public Long id() {
+        return id;
+    }
+
+    public Type type() {
+        return type;
+    }
+
+    public String firstName() {
+        return first_name;
+    }
+
+    public String lastName() {
+        return last_name;
+    }
+
+    public String username() {
+        return username;
+    }
+
+    public Boolean isForum() {
+        return is_forum != null && is_forum;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public ChatPhoto photo() {
+        return photo;
+    }
+
+    /**
+     * @deprecated Use activeUsernames() instead
+     */
+    @Deprecated
+    public String[] getActiveUsernames() {
+        return active_usernames;
+    }
+
+    public String[] activeUsernames() {
+        return active_usernames;
+    }
+
+    public Birthdate birthdate() {
+        return birthdate;
+    }
+
+    public BusinessIntro businessIntro() {
+        return business_intro;
+    }
+
+    public BusinessLocation businessLocation() {
+        return business_location;
+    }
+
+    public BusinessOpeningHours businessOpeningHours() {
+        return business_opening_hours;
+    }
+
+    public Chat personalChat() {
+        return personal_chat;
+    }
+
+    public ReactionType[] availableReactions() {
+        return available_reactions;
+    }
+
+    public Integer accentColorId() {
+        return accent_color_id;
+    }
+
+    public String backgroundCustomEmojiId() {
+        return background_custom_emoji_id;
+    }
+
+    public Integer profileAccentColorId() {
+        return profile_accent_color_id;
+    }
+
+    public String profileBackgroundCustomEmojiId() {
+        return profile_background_custom_emoji_id;
+    }
+
+    /**
+     * @deprecated Use emojiStatusCustomEmojiId() instead
+     */
+    @Deprecated
+    public String getEmojiStatusCustomEmojiId() {
+        return emoji_status_custom_emoji_id;
+    }
+
+    public String emojiStatusCustomEmojiId() {
+        return emoji_status_custom_emoji_id;
+    }
+
+    public Integer emojiStatusExpirationDate() {
+        return emoji_status_expiration_date;
+    }
+
+    public String bio() {
+        return bio;
+    }
+
+    public Boolean hasPrivateForwards() {
+        return has_private_forwards != null && has_private_forwards;
+    }
+
+    public Boolean hasRestrictedVoiceAndVideoMessages() {
+        return has_restricted_voice_and_video_messages != null && has_restricted_voice_and_video_messages;
+    }
+
+    public Boolean hasHiddenMembers() {
+        return has_hidden_members != null && has_hidden_members;
+    }
+
+    public Boolean hasAggressiveAntiSpamEnabled() {
+        return has_aggressive_anti_spam_enabled != null && has_aggressive_anti_spam_enabled;
+    }
+
+    public Boolean joinToSendMessages() {
+        return join_to_send_messages != null && join_to_send_messages;
+    }
+
+    public Boolean joinByRequest() {
+        return join_by_request != null && join_by_request;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public String inviteLink() {
+        return invite_link;
+    }
+
+    public Message pinnedMessage() {
+        return pinned_message;
+    }
+
+    public ChatPermissions permissions() {
+        return permissions;
+    }
+
+    public Integer slowModeDelay() {
+        return slow_mode_delay;
+    }
+
+    public Integer unrestrictBoostCount() {
+        return unrestrict_boost_count;
+    }
+
+    public Integer messageAutoDeleteTime() {
+        return message_auto_delete_time;
+    }
+
+    public Boolean hasProtectedContent() {
+        return has_protected_content != null && has_protected_content;
+    }
+
+    public Boolean hasVisibleHistory() {
+        return has_visible_history != null && has_visible_history;
+    }
+
+    public String stickerSetName() {
+        return sticker_set_name;
+    }
+
+    public Boolean canSetStickerSet() {
+        return can_set_sticker_set != null && can_set_sticker_set;
+    }
+
+    public String customEmojiStickerSetName() {
+        return custom_emoji_sticker_set_name;
+    }
+
+    public Long linkedChatId() {
+        return linked_chat_id;
+    }
+
+    public ChatLocation location() {
+        return location;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ChatFullInfo chat = (ChatFullInfo) o;
+        return Objects.equals(id, chat.id) &&
+                type == chat.type &&
+                Objects.equals(first_name, chat.first_name) &&
+                Objects.equals(last_name, chat.last_name) &&
+                Objects.equals(is_forum, chat.is_forum) &&
+                Objects.equals(username, chat.username) &&
+                Objects.equals(title, chat.title) &&
+                Objects.equals(photo, chat.photo) &&
+                Arrays.equals(active_usernames, chat.active_usernames) &&
+                Objects.equals(birthdate, chat.birthdate) &&
+                Objects.equals(business_intro, chat.business_intro) &&
+                Objects.equals(business_location, chat.business_location) &&
+                Objects.equals(business_opening_hours, chat.business_opening_hours) &&
+                Objects.equals(personal_chat, chat.personal_chat) &&
+                Arrays.equals(available_reactions, chat.available_reactions) &&
+                Objects.equals(accent_color_id, chat.accent_color_id) &&
+                Objects.equals(background_custom_emoji_id, chat.background_custom_emoji_id) &&
+                Objects.equals(profile_accent_color_id, chat.profile_accent_color_id) &&
+                Objects.equals(profile_background_custom_emoji_id, chat.profile_background_custom_emoji_id) &&
+                Objects.equals(emoji_status_custom_emoji_id, chat.emoji_status_custom_emoji_id) &&
+                Objects.equals(emoji_status_expiration_date, chat.emoji_status_expiration_date) &&
+                Objects.equals(bio, chat.bio) &&
+                Objects.equals(has_private_forwards, chat.has_private_forwards) &&
+                Objects.equals(has_restricted_voice_and_video_messages, chat.has_restricted_voice_and_video_messages) &&
+                Objects.equals(has_hidden_members, chat.has_hidden_members) &&
+                Objects.equals(has_aggressive_anti_spam_enabled, chat.has_aggressive_anti_spam_enabled) &&
+                Objects.equals(join_to_send_messages, chat.join_to_send_messages) &&
+                Objects.equals(join_by_request, chat.join_by_request) &&
+                Objects.equals(description, chat.description) &&
+                Objects.equals(invite_link, chat.invite_link) &&
+                Objects.equals(pinned_message, chat.pinned_message) &&
+                Objects.equals(permissions, chat.permissions) &&
+                Objects.equals(slow_mode_delay, chat.slow_mode_delay) &&
+                Objects.equals(unrestrict_boost_count, chat.unrestrict_boost_count) &&
+                Objects.equals(message_auto_delete_time, chat.message_auto_delete_time) &&
+                Objects.equals(has_protected_content, chat.has_protected_content) &&
+                Objects.equals(has_visible_history, chat.has_visible_history) &&
+                Objects.equals(sticker_set_name, chat.sticker_set_name) &&
+                Objects.equals(can_set_sticker_set, chat.can_set_sticker_set) &&
+                Objects.equals(custom_emoji_sticker_set_name, chat.custom_emoji_sticker_set_name) &&
+                Objects.equals(linked_chat_id, chat.linked_chat_id) &&
+                Objects.equals(location, chat.location);
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "ChatFullInfo{" +
+                "id=" + id +
+                ", type=" + type +
+                ", first_name='" + first_name + '\'' +
+                ", last_name='" + last_name + '\'' +
+                ", is_forum=" + is_forum +
+                ", username='" + username + '\'' +
+                ", title='" + title + '\'' +
+                ", photo=" + photo +
+                ", active_usernames=" + Arrays.toString(active_usernames) +
+                ", birthdate=" + birthdate +
+                ", business_intro=" + business_intro +
+                ", business_location=" + business_location +
+                ", business_opening_hours=" + business_opening_hours +
+                ", personal_chat=" + personal_chat +
+                ", available_reactions=" + Arrays.toString(available_reactions) +
+                ", accent_color_id=" + accent_color_id +
+                ", background_custom_emoji_id='" + background_custom_emoji_id + '\'' +
+                ", profile_accent_color_id=" + profile_accent_color_id +
+                ", profile_background_custom_emoji_id='" + profile_background_custom_emoji_id + '\'' +
+                ", emoji_status_custom_emoji_id='" + emoji_status_custom_emoji_id + '\'' +
+                ", emoji_status_expiration_date='" + emoji_status_expiration_date + '\'' +
+                ", bio='" + bio + '\'' +
+                ", has_private_forwards=" + has_private_forwards +
+                ", has_restricted_voice_and_video_messages=" + has_restricted_voice_and_video_messages +
+                ", has_hidden_members=" + has_hidden_members +
+                ", has_aggressive_anti_spam_enabled=" + has_aggressive_anti_spam_enabled +
+                ", join_to_send_messages=" + join_to_send_messages +
+                ", join_by_request=" + join_by_request +
+                ", description='" + description + '\'' +
+                ", invite_link='" + invite_link + '\'' +
+                ", pinned_message=" + pinned_message +
+                ", permissions=" + permissions +
+                ", slow_mode_delay=" + slow_mode_delay +
+                ", unrestrict_boost_count=" + unrestrict_boost_count +
+                ", message_auto_delete_time=" + message_auto_delete_time +
+                ", has_protected_content=" + has_protected_content +
+                ", has_visible_history=" + has_visible_history +
+                ", sticker_set_name='" + sticker_set_name + '\'' +
+                ", can_set_sticker_set=" + can_set_sticker_set +
+                ", custom_emoji_sticker_set_name=" + custom_emoji_sticker_set_name +
+                ", linked_chat_id=" + linked_chat_id +
+                ", location=" + location +
+                '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/ChatMemberUpdated.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/ChatMemberUpdated.java
@@ -17,6 +17,7 @@ public class ChatMemberUpdated implements Serializable {
     private ChatMember new_chat_member;
     private ChatInviteLink invite_link;
     private Boolean via_chat_folder_invite_link;
+    private Boolean via_join_request;
 
     public Chat chat() {
         return chat;
@@ -46,6 +47,11 @@ public class ChatMemberUpdated implements Serializable {
         return via_chat_folder_invite_link;
     }
 
+    public Boolean viaJoinRequest() {
+        return via_join_request;
+    }
+
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -57,12 +63,13 @@ public class ChatMemberUpdated implements Serializable {
                 Objects.equals(old_chat_member, that.old_chat_member) &&
                 Objects.equals(new_chat_member, that.new_chat_member) &&
                 Objects.equals(invite_link, that.invite_link) &&
-                Objects.equals(via_chat_folder_invite_link, that.via_chat_folder_invite_link);
+                Objects.equals(via_chat_folder_invite_link, that.via_chat_folder_invite_link) &&
+                Objects.equals(via_join_request, that.via_join_request);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(chat, from, date, old_chat_member, new_chat_member, invite_link, via_chat_folder_invite_link);
+        return Objects.hash(chat, from, date, old_chat_member, new_chat_member, invite_link, via_chat_folder_invite_link, via_join_request);
     }
 
     @Override
@@ -75,6 +82,7 @@ public class ChatMemberUpdated implements Serializable {
                 ", new_chat_member=" + new_chat_member +
                 ", invite_link=" + invite_link +
                 ", via_chat_folder_invite_link=" + via_chat_folder_invite_link +
+                ", via_join_request=" + via_join_request +
                 '}';
     }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/model/Message.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Message.java
@@ -43,6 +43,7 @@ public class Message extends MaybeInaccessibleMessage implements Serializable {
     private MessageEntity[] entities;
     private MessageEntity[] caption_entities;
     private LinkPreviewOptions link_preview_options;
+    private String effect_id;
     private Audio audio;
     private Document document;
     private Animation animation;
@@ -265,6 +266,11 @@ public class Message extends MaybeInaccessibleMessage implements Serializable {
     public LinkPreviewOptions linkPreviewOptions() {
         return link_preview_options;
     }
+
+    public String effectId() {
+        return effect_id;
+    }
+
     public Audio audio() {
         return audio;
     }
@@ -526,6 +532,7 @@ public class Message extends MaybeInaccessibleMessage implements Serializable {
                 Arrays.equals(entities, message.entities) &&
                 Arrays.equals(caption_entities, message.caption_entities) &&
                 Objects.equals(link_preview_options, message.link_preview_options) &&
+                Objects.equals(effect_id, message.effect_id) &&
                 Objects.equals(audio, message.audio) &&
                 Objects.equals(document, message.document) &&
                 Objects.equals(animation, message.animation) &&
@@ -614,6 +621,7 @@ public class Message extends MaybeInaccessibleMessage implements Serializable {
                 ", entities=" + Arrays.toString(entities) +
                 ", caption_entities=" + Arrays.toString(caption_entities) +
                 ", link_preview_options=" + link_preview_options +
+                ", effect_id=" + effect_id +
                 ", audio=" + audio +
                 ", document=" + document +
                 ", animation=" + animation +

--- a/library/src/main/java/com/pengrad/telegrambot/model/Message.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Message.java
@@ -1,6 +1,7 @@
 package com.pengrad.telegrambot.model;
 
 import com.pengrad.telegrambot.model.business.BusinessConnection;
+import com.pengrad.telegrambot.model.chatbackground.ChatBackground;
 import com.pengrad.telegrambot.model.chatboost.ChatBoostAdded;
 import com.pengrad.telegrambot.model.message.MaybeInaccessibleMessage;
 import com.pengrad.telegrambot.model.message.origin.*;
@@ -79,6 +80,7 @@ public class Message extends MaybeInaccessibleMessage implements Serializable {
     private PassportData passport_data;
     private ProximityAlertTriggered proximity_alert_triggered;
     private ChatBoostAdded boost_added;
+    private ChatBackground chat_background_set;
     private ForumTopicCreated forum_topic_created;
     private ForumTopicEdited forum_topic_edited;
     private ForumTopicClosed forum_topic_closed;
@@ -415,6 +417,10 @@ public class Message extends MaybeInaccessibleMessage implements Serializable {
         return boost_added;
     }
 
+    public ChatBackground chatBackgroundSet() {
+        return chat_background_set;
+    }
+
     public ForumTopicCreated forumTopicCreated() {
         return forum_topic_created;
     }
@@ -557,6 +563,7 @@ public class Message extends MaybeInaccessibleMessage implements Serializable {
                 Objects.equals(passport_data, message.passport_data) &&
                 Objects.equals(proximity_alert_triggered, message.proximity_alert_triggered) &&
                 Objects.equals(boost_added, message.boost_added) &&
+                Objects.equals(chat_background_set, message.chat_background_set) &&
                 Objects.equals(forum_topic_created, message.forum_topic_created) &&
                 Objects.equals(forum_topic_edited, message.forum_topic_edited) &&
                 Objects.equals(forum_topic_closed, message.forum_topic_closed) &&
@@ -644,6 +651,7 @@ public class Message extends MaybeInaccessibleMessage implements Serializable {
                 ", passport_data=" + passport_data +
                 ", proximity_alert_triggered=" + proximity_alert_triggered +
                 ", boost_added=" + boost_added +
+                ", chat_background_set=" + chat_background_set +
                 ", forum_topic_created=" + forum_topic_created +
                 ", forum_topic_edited=" + forum_topic_edited +
                 ", forum_topic_closed=" + forum_topic_closed +

--- a/library/src/main/java/com/pengrad/telegrambot/model/Message.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Message.java
@@ -42,6 +42,7 @@ public class Message extends MaybeInaccessibleMessage implements Serializable {
     private String text;
     private MessageEntity[] entities;
     private MessageEntity[] caption_entities;
+    private Boolean show_caption_above_media;
     private LinkPreviewOptions link_preview_options;
     private String effect_id;
     private Audio audio;
@@ -261,6 +262,10 @@ public class Message extends MaybeInaccessibleMessage implements Serializable {
 
     public MessageEntity[] captionEntities() {
         return caption_entities;
+    }
+
+    public Boolean showCaptionAboveMedia() {
+        return show_caption_above_media;
     }
 
     public LinkPreviewOptions linkPreviewOptions() {
@@ -531,6 +536,7 @@ public class Message extends MaybeInaccessibleMessage implements Serializable {
                 Objects.equals(text, message.text) &&
                 Arrays.equals(entities, message.entities) &&
                 Arrays.equals(caption_entities, message.caption_entities) &&
+                Objects.equals(show_caption_above_media, message.show_caption_above_media) &&
                 Objects.equals(link_preview_options, message.link_preview_options) &&
                 Objects.equals(effect_id, message.effect_id) &&
                 Objects.equals(audio, message.audio) &&
@@ -620,6 +626,7 @@ public class Message extends MaybeInaccessibleMessage implements Serializable {
                 ", text='" + text + '\'' +
                 ", entities=" + Arrays.toString(entities) +
                 ", caption_entities=" + Arrays.toString(caption_entities) +
+                ", show_caption_above_media=" + show_caption_above_media +
                 ", link_preview_options=" + link_preview_options +
                 ", effect_id=" + effect_id +
                 ", audio=" + audio +

--- a/library/src/main/java/com/pengrad/telegrambot/model/MessageEntity.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/MessageEntity.java
@@ -12,7 +12,7 @@ public class MessageEntity implements Serializable {
 
     public enum Type {
         mention, hashtag, cashtag, bot_command, url, email, phone_number, bold, italic, code, pre, text_link,
-        text_mention, underline, strikethrough, spoiler, custom_emoji, blockquote
+        text_mention, underline, strikethrough, spoiler, custom_emoji, blockquote, expandable_blockquote
     }
 
     private Type type;

--- a/library/src/main/java/com/pengrad/telegrambot/model/Poll.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/Poll.java
@@ -16,6 +16,7 @@ public class Poll implements Serializable {
 
     private String id;
     private String question;
+    private MessageEntity[] question_entities;
     private PollOption[] options;
     private Integer total_voter_count;
     private Boolean is_closed;
@@ -34,6 +35,10 @@ public class Poll implements Serializable {
 
     public String question() {
         return question;
+    }
+    
+    public MessageEntity[] questionEntities() {
+        return question_entities;
     }
 
     public PollOption[] options() {
@@ -89,7 +94,7 @@ public class Poll implements Serializable {
 
         if (id != null ? !id.equals(poll.id) : poll.id != null) return false;
         if (question != null ? !question.equals(poll.question) : poll.question != null) return false;
-        // Probably incorrect - comparing Object[] arrays with Arrays.equals
+        if (!Arrays.equals(question_entities, poll.question_entities)) return false;
         if (!Arrays.equals(options, poll.options)) return false;
         if (total_voter_count != null ? !total_voter_count.equals(poll.total_voter_count) : poll.total_voter_count != null)
             return false;
@@ -101,7 +106,6 @@ public class Poll implements Serializable {
         if (correct_option_id != null ? !correct_option_id.equals(poll.correct_option_id) : poll.correct_option_id != null)
             return false;
         if (explanation != null ? !explanation.equals(poll.explanation) : poll.explanation != null) return false;
-        // Probably incorrect - comparing Object[] arrays with Arrays.equals
         if (!Arrays.equals(explanation_entities, poll.explanation_entities)) return false;
         if (open_period != null ? !open_period.equals(poll.open_period) : poll.open_period != null) return false;
         return close_date != null ? close_date.equals(poll.close_date) : poll.close_date == null;
@@ -118,6 +122,7 @@ public class Poll implements Serializable {
                 "id='" + id + '\'' +
                 ", question='" + question + '\'' +
                 ", options=" + Arrays.toString(options) +
+                ", question_entities=" + Arrays.toString(question_entities) +
                 ", total_voter_count=" + total_voter_count +
                 ", is_closed=" + is_closed +
                 ", is_anonymous=" + is_anonymous +

--- a/library/src/main/java/com/pengrad/telegrambot/model/PollOption.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/PollOption.java
@@ -1,6 +1,7 @@
 package com.pengrad.telegrambot.model;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 /**
  * Stas Parshin

--- a/library/src/main/java/com/pengrad/telegrambot/model/PollOption.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/PollOption.java
@@ -11,6 +11,7 @@ public class PollOption implements Serializable {
 
     private String text;
     private Integer voter_count;
+    private MessageEntity[] text_entities;
 
     public String text() {
         return text;
@@ -20,12 +21,18 @@ public class PollOption implements Serializable {
         return voter_count;
     }
 
+    public MessageEntity[] textEntities() {
+        return text_entities;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
         PollOption that = (PollOption) o;
+
+        if (!Arrays.equals(text_entities, that.text_entities)) return false;
 
         if (text != null ? !text.equals(that.text) : that.text != null) return false;
         return voter_count != null ? voter_count.equals(that.voter_count) : that.voter_count == null;
@@ -43,6 +50,7 @@ public class PollOption implements Serializable {
         return "PollOption{" +
                 "text='" + text + '\'' +
                 ", voter_count=" + voter_count +
+                ", text_entities=" + Arrays.toString(text_entities) +
                 '}';
     }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundFill.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundFill.java
@@ -1,0 +1,36 @@
+package com.pengrad.telegrambot.model.chatbackground;
+
+import java.util.Objects;
+
+public abstract class BackgroundFill {
+
+    private final String type;
+
+    public BackgroundFill(String type) {
+        this.type = type;
+    }
+
+    public String type() {
+        return type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BackgroundFill that = (BackgroundFill) o;
+        return Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type);
+    }
+
+    @Override
+    public String toString() {
+        return "BackgroundFill{" +
+            "type='" + type + '\'' +
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundFillFreeformGradient.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundFillFreeformGradient.java
@@ -1,0 +1,40 @@
+package com.pengrad.telegrambot.model.chatbackground;
+
+import java.util.Arrays;
+
+public class BackgroundFillFreeformGradient extends BackgroundType {
+
+    public static final String TYPE = "freeform_gradient";
+
+    private Integer[] colors;
+
+    public BackgroundFillFreeformGradient(Integer... colors) {
+        super(TYPE);
+        this.colors = colors;
+    }
+
+    public Integer[] colors() {
+        return colors;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BackgroundFillFreeformGradient that = (BackgroundFillFreeformGradient) o;
+        return Arrays.equals(colors, that.colors);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(colors);
+    }
+
+    @Override
+    public String toString() {
+        return "BackgroundFillFreeformGradient{" +
+            "type='" + type() + '\'' +
+            ", colors=" + Arrays.asList(colors) + 
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundFillGradient.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundFillGradient.java
@@ -1,0 +1,54 @@
+package com.pengrad.telegrambot.model.chatbackground;
+
+import java.util.Objects;
+
+public class BackgroundFillGradient extends BackgroundType {
+
+    public static final String TYPE = "gradient";
+
+    private Integer top_color;
+    private Integer bottom_color;
+    private Integer rotation_angle;
+
+    public BackgroundFillGradient(Integer topColor, Integer bottomColor, Integer rotationAngle) {
+        super(TYPE);
+        this.top_color = topColor;
+        this.bottom_color = bottomColor;
+        this.rotation_angle = rotationAngle;
+    }
+
+    public Integer topColor() {
+        return top_color;
+    }
+
+    public Integer bottomColor() {
+        return bottom_color;
+    }
+
+    public Integer rotationAngle() {
+        return rotation_angle;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BackgroundFillGradient that = (BackgroundFillGradient) o;
+        return Objects.equals(top_color, that.top_color) && Objects.equals(bottom_color, that.bottom_color) && Objects.equals(rotation_angle, that.rotation_angle);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(top_color, bottom_color, rotation_angle);
+    }
+
+    @Override
+    public String toString() {
+        return "BackgroundFillGradient{" +
+            "type='" + type() + '\'' +
+            ", top_color=" + top_color + 
+            ", bottom_color=" + bottom_color + 
+            ", rotation_angle=" + rotation_angle + 
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundFillSolid.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundFillSolid.java
@@ -1,0 +1,40 @@
+package com.pengrad.telegrambot.model.chatbackground;
+
+import java.util.Objects;
+
+public class BackgroundFillSolid extends BackgroundType {
+
+    public static final String TYPE = "solid";
+
+    private Integer color;
+
+    public BackgroundFillSolid(Integer color) {
+        super(TYPE);
+        this.color = color;
+    }
+
+    public Integer color() {
+        return color;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BackgroundFillSolid that = (BackgroundFillSolid) o;
+        return Objects.equals(color, that.color);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(color);
+    }
+
+    @Override
+    public String toString() {
+        return "BackgroundFillSolid{" +
+            "type='" + type() + '\'' +
+            ", color=" + color + 
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundType.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundType.java
@@ -1,0 +1,36 @@
+package com.pengrad.telegrambot.model.chatbackground;
+
+import java.util.Objects;
+
+public abstract class BackgroundType {
+
+    private final String type;
+
+    public BackgroundType(String type) {
+        this.type = type;
+    }
+
+    public String type() {
+        return type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BackgroundType that = (BackgroundType) o;
+        return Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type);
+    }
+
+    @Override
+    public String toString() {
+        return "BackgroundType{" +
+            "type='" + type + '\'' +
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundTypeChatTheme.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundTypeChatTheme.java
@@ -1,0 +1,40 @@
+package com.pengrad.telegrambot.model.chatbackground;
+
+import java.util.Objects;
+
+public class BackgroundTypeChatTheme extends BackgroundType {
+
+    public static final String TYPE = "chat_theme";
+
+    private String theme_name;
+
+    public BackgroundTypeChatTheme(String themeName) {
+        super(TYPE);
+        this.theme_name = themeName;
+    }
+
+    public String themeName() {
+        return theme_name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BackgroundTypeChatTheme that = (BackgroundTypeChatTheme) o;
+        return Objects.equals(theme_name, that.theme_name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(theme_name);
+    }
+
+    @Override
+    public String toString() {
+        return "BackgroundTypeChatTheme{" +
+            "type='" + type() + '\'' +
+            ", theme_name=" + theme_name + 
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundTypeFill.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundTypeFill.java
@@ -1,0 +1,48 @@
+package com.pengrad.telegrambot.model.chatbackground;
+
+import java.util.Objects;
+
+public class BackgroundTypeFill extends BackgroundType {
+
+    public static final String TYPE = "fill";
+
+    private BackgroundFill fill;
+    private Integer dark_theme_dimming;
+
+    public BackgroundTypeFill(BackgroundFill fill, Integer darkThemeDimming) {
+        super(TYPE);
+        this.fill = fill;
+        this.dark_theme_dimming = darkThemeDimming;
+    }
+
+    public BackgroundFill fill() {
+        return fill;
+    }
+
+    public Integer darkThemeDimming() {
+        return dark_theme_dimming;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BackgroundTypeFill that = (BackgroundTypeFill) o;
+        return Objects.equals(fill, that.fill) &&
+                Objects.equals(dark_theme_dimming, that.dark_theme_dimming);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fill, dark_theme_dimming);
+    }
+
+    @Override
+    public String toString() {
+        return "BackgroundTypeFill{" +
+            "type='" + type() + '\'' +
+            ", fill='" + fill + '\'' +
+            ", dark_theme_dimming=" + dark_theme_dimming +
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundTypePattern.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundTypePattern.java
@@ -1,0 +1,82 @@
+package com.pengrad.telegrambot.model.chatbackground;
+
+import java.util.Objects;
+
+import com.pengrad.telegrambot.model.Document;
+
+public class BackgroundTypePattern extends BackgroundType {
+
+    public static final String TYPE = "pattern";
+
+    private Document document;
+    private BackgroundFill fill;
+    private Integer intensity;
+    private Boolean is_inverted;
+    private Boolean is_moving;
+
+    public BackgroundTypePattern(Document document, BackgroundFill fill, Integer intensity) {
+        super(TYPE);
+        this.document = document;
+        this.fill = fill;
+        this.intensity = intensity;
+    }
+
+    public Document document() {
+        return document;
+    }
+
+    public BackgroundFill fill() {
+        return fill;
+    }
+
+    public Integer intensity() {
+        return intensity;
+    }
+
+    public Boolean isInverted() {
+        return is_inverted;
+    }
+
+    public Boolean isMoving() {
+        return is_moving;
+    }
+
+    public BackgroundTypePattern isInverted(Boolean isInverted) {
+        this.is_inverted = isInverted;
+        return this;
+    }
+
+    public BackgroundTypePattern isMoving(Boolean isMoving) {
+        this.is_moving = isMoving;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BackgroundTypePattern that = (BackgroundTypePattern) o;
+        return Objects.equals(document, that.document) &&
+                Objects.equals(fill, that.fill) &&
+                Objects.equals(intensity, that.intensity) &&
+                Objects.equals(is_inverted, that.is_inverted) &&
+                Objects.equals(is_moving, that.is_moving);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(document, fill, intensity, is_inverted, is_moving);
+    }
+
+    @Override
+    public String toString() {
+        return "BackgroundTypePattern{" +
+            "type='" + type() + '\'' +
+            ", document='" + document + '\'' +
+            ", fill=" + fill +
+            ", intensity=" + intensity +
+            ", is_inverted=" + is_inverted +
+            ", is_moving=" + is_moving +
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundTypeWallpaper.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundTypeWallpaper.java
@@ -1,0 +1,74 @@
+package com.pengrad.telegrambot.model.chatbackground;
+
+import java.util.Objects;
+
+import com.pengrad.telegrambot.model.Document;
+
+public class BackgroundTypeWallpaper extends BackgroundType {
+
+    public static final String TYPE = "wallpaper";
+
+    private Document document;
+    private Integer dark_theme_dimming;
+    private Boolean is_blurred;
+    private Boolean is_moving;
+
+    public BackgroundTypeWallpaper(Document document, Integer darkThemeDimming) {
+        super(TYPE);
+        this.document = document;
+        this.dark_theme_dimming = darkThemeDimming;
+    }
+
+    public Document document() {
+        return document;
+    }
+
+    public Integer darkThemeDimming() {
+        return dark_theme_dimming;
+    }
+
+    public Boolean isBlurred() {
+        return is_blurred;
+    }
+
+    public Boolean isMoving() {
+        return is_moving;
+    }
+
+    public BackgroundTypeWallpaper isBlurred(Boolean isBlurred) {
+        this.is_blurred = isBlurred;
+        return this;
+    }
+
+    public BackgroundTypeWallpaper isMoving(Boolean isMoving) {
+        this.is_moving = isMoving;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BackgroundTypeWallpaper that = (BackgroundTypeWallpaper) o;
+        return Objects.equals(document, that.document) &&
+                Objects.equals(dark_theme_dimming, that.dark_theme_dimming) &&
+                Objects.equals(is_blurred, that.is_blurred) &&
+                Objects.equals(is_moving, that.is_moving);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(document, dark_theme_dimming, is_blurred, is_moving);
+    }
+
+    @Override
+    public String toString() {
+        return "BackgroundTypeWallpaper{" +
+            "type='" + type() + '\'' +
+            ", document='" + document + '\'' +
+            ", dark_theme_dimming=" + dark_theme_dimming +
+            ", is_blurred=" + is_blurred +
+            ", is_moving=" + is_moving +
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/ChatBackground.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/ChatBackground.java
@@ -1,0 +1,34 @@
+package com.pengrad.telegrambot.model.chatbackground;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+
+public class ChatBackground implements Serializable {
+
+    private final static long serialVersionUID = 0L;
+
+    private BackgroundType type;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ChatBackground that = (ChatBackground) o;
+
+        return Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type);
+    }
+
+    @Override
+    public String toString() {
+        return "ChatBackground{" +
+                "type=" + type +
+                '}';
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/request/InlineQueryResult.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/request/InlineQueryResult.java
@@ -19,6 +19,7 @@ public abstract class InlineQueryResult<T extends InlineQueryResult<T>> implemen
     private MessageEntity[] caption_entities;
     private InputMessageContent input_message_content;
     private InlineKeyboardMarkup reply_markup;
+    private Boolean show_caption_above_media;
 
     public InlineQueryResult(String type, String id) {
         this.type = type;
@@ -39,4 +40,10 @@ public abstract class InlineQueryResult<T extends InlineQueryResult<T>> implemen
         this.reply_markup = replyMarkup;
         return thisAsT;
     }
+
+    public T showCaptionAboveMedia(Boolean showCaptionAboveMedia) {
+        this.show_caption_above_media = showCaptionAboveMedia;
+        return thisAsT;
+    }
+
 }

--- a/library/src/main/java/com/pengrad/telegrambot/model/request/InputInvoiceMessageContent.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/request/InputInvoiceMessageContent.java
@@ -35,6 +35,18 @@ public class InputInvoiceMessageContent extends InputMessageContent implements S
     private boolean is_flexible;
 
 
+    public InputInvoiceMessageContent(String title, String description, String payload, String currency, LabeledPrice[] prices) {
+        this.title = title;
+        this.description = description;
+        this.payload = payload;
+        this.currency = currency;
+        this.prices = prices;
+    }
+
+    /**
+     * Backward compatibility: API 7.4, parameter "provider_token" became optional
+     * @deprecated Use constrcutor without 'provider_token' instead
+     */
     public InputInvoiceMessageContent(String title, String description, String payload, String providerToken, String currency, LabeledPrice[] prices) {
         this.title = title;
         this.description = description;
@@ -42,6 +54,11 @@ public class InputInvoiceMessageContent extends InputMessageContent implements S
         this.provider_token = providerToken;
         this.currency = currency;
         this.prices = prices;
+    }
+
+    public InputInvoiceMessageContent providerToken(String providerToken) {
+        this.provider_token = providerToken;
+        return this;
     }
 
     public InputInvoiceMessageContent maxTipAmount(Integer maxTipAmount) {

--- a/library/src/main/java/com/pengrad/telegrambot/model/request/InputMedia.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/request/InputMedia.java
@@ -21,6 +21,7 @@ abstract public class InputMedia<T extends InputMedia<T>> implements Serializabl
     private final String type;
     private final String media;
     private String thumbnail;
+    private Boolean show_caption_above_media;
 
     private String caption;
     private String parse_mode;
@@ -69,6 +70,11 @@ abstract public class InputMedia<T extends InputMedia<T>> implements Serializabl
         String attachName = AttachName.next();
         attachments.put(attachName, thumb);
         this.thumbnail = "attach://" + attachName;
+        return thisAsT;
+    }
+
+    public T showCaptionAboveMedia(Boolean showCaptionAboveMedia) {
+        this.show_caption_above_media = showCaptionAboveMedia;
         return thisAsT;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/request/InputPollOption.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/request/InputPollOption.java
@@ -1,0 +1,55 @@
+package com.pengrad.telegrambot.model.request;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+
+import com.pengrad.telegrambot.model.MessageEntity;
+
+public class InputPollOption implements Serializable {
+
+    private final static long serialVersionUID = 0L;
+
+    private String text;
+    private String text_parse_mode;
+    private MessageEntity[] text_entities;
+
+    public InputPollOption(String text) {
+        this.text = text;
+    }
+
+
+    public InputPollOption textParseMode(String textParseMode) {
+        this.text_parse_mode = textParseMode;
+        return this;
+    }
+
+    public InputPollOption textEntities(MessageEntity... entities) {
+        this.text_entities = entities;
+        return this;
+    }    
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof InputPollOption)) return false;
+        InputPollOption that = (InputPollOption) o;
+        return Objects.equals(text, that.text)
+            && Objects.equals(text_parse_mode, that.text_parse_mode)
+            && Arrays.equals(text_entities, that.text_entities);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(text, text_parse_mode, text_entities);
+    }
+
+    @Override
+    public String toString() {
+        return "InputPollOption{" +
+            "text='" + text + '\'' +
+            ", text_parse_mode='" + text_parse_mode + '\'' +
+            ", text_entities=" + Arrays.toString(text_entities) +
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/AbstractSendRequest.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/AbstractSendRequest.java
@@ -15,6 +15,10 @@ abstract public class AbstractSendRequest<T extends AbstractSendRequest<T>> exte
         add("chat_id", chatId);
     }
 
+    public T messageEffectId(String messageEffectId) {
+        return add("message_effect_id", messageEffectId);
+    }
+
     public T businessConnectionId(String businessConnectionId) {
         return add("business_connection_id", businessConnectionId);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/CopyMessages.kt
+++ b/library/src/main/java/com/pengrad/telegrambot/request/CopyMessages.kt
@@ -26,4 +26,8 @@ class CopyMessages(
     fun protectContent(protectContent: Boolean): CopyMessages {
         return add("protect_content", protectContent)
     }
+
+    fun showCaptionAboveMedia(showCaptionAboveMedia: Boolean): CopyMessages {
+        return add("show_caption_above_media", showCaptionAboveMedia)
+    }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/request/CreateInvoiceLink.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/CreateInvoiceLink.java
@@ -9,6 +9,17 @@ import com.pengrad.telegrambot.response.StringResponse;
  */
 public class CreateInvoiceLink extends BaseRequest<CreateInvoiceLink, StringResponse> {
 
+    public CreateInvoiceLink(String title, String description, String payload, String currency, LabeledPrice... prices) {
+        super(StringResponse.class);
+        add("title", title).add("description", description).add("payload", payload)
+            .add("currency", currency).add("prices", prices);
+    }
+
+
+    /**
+     * Backward compatibility: API 7.4, parameter "provider_token" became optional
+     * @deprecated Use constrcutor without 'provider_token' instead
+     */
     public CreateInvoiceLink(String title, String description, String payload, String providerToken,
                              String currency, LabeledPrice... prices) {
         super(StringResponse.class);
@@ -16,6 +27,9 @@ public class CreateInvoiceLink extends BaseRequest<CreateInvoiceLink, StringResp
                 .add("provider_token", providerToken).add("currency", currency).add("prices", prices);
     }
 
+    public CreateInvoiceLink providerToken(String providerToken) {
+        return add("provider_token", providerToken);
+    }
 
     /**
      * @param maxTipAmount The maximum accepted amount for tips in the smallest units of the currency

--- a/library/src/main/java/com/pengrad/telegrambot/request/EditMessageCaption.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/EditMessageCaption.java
@@ -38,4 +38,8 @@ public class EditMessageCaption extends BaseRequest<EditMessageCaption, BaseResp
         return add("reply_markup", replyMarkup);
     }
 
+    public EditMessageCaption showCaptionAboveMedia(Boolean showCaptionAboveMedia) {
+        return add("show_caption_above_media", showCaptionAboveMedia);
+    }
+
 }

--- a/library/src/main/java/com/pengrad/telegrambot/request/EditMessageLiveLocation.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/EditMessageLiveLocation.java
@@ -35,4 +35,10 @@ public class EditMessageLiveLocation extends BaseRequest<EditMessageLiveLocation
     public EditMessageLiveLocation replyMarkup(InlineKeyboardMarkup replyMarkup) {
         return add("reply_markup", replyMarkup);
     }
+
+    public EditMessageLiveLocation livePeriod(int livePeriod) {
+        return add("live_period", livePeriod);
+    }
+
+
 }

--- a/library/src/main/java/com/pengrad/telegrambot/request/RefundStarPayment.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/RefundStarPayment.java
@@ -1,0 +1,13 @@
+package com.pengrad.telegrambot.request;
+
+import com.pengrad.telegrambot.response.BaseResponse;
+
+
+public class RefundStarPayment extends BaseRequest<RefundStarPayment, BaseResponse> {
+
+    public RefundStarPayment(Long userId, String telegramPaymentChargeId) {
+        super(BaseResponse.class);
+        add("user_id", telegramPaymentChargeId).add("telegram_payment_charge_id", telegramPaymentChargeId);
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/SendAnimation.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SendAnimation.java
@@ -75,6 +75,10 @@ public class SendAnimation extends AbstractMultipartRequest<SendAnimation> {
         return add("has_spoiler", has_spoiler);
     }
 
+    public SendAnimation showCaptionAboveMedia(Boolean showCaptionAboveMedia) {
+        return add("show_caption_above_media", showCaptionAboveMedia);
+    }
+
     @Override
     protected String getFileParamName() {
         return "animation";

--- a/library/src/main/java/com/pengrad/telegrambot/request/SendInvoice.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SendInvoice.java
@@ -8,6 +8,18 @@ import com.pengrad.telegrambot.model.request.LabeledPrice;
  */
 public class SendInvoice extends AbstractSendRequest<SendInvoice> {
 
+
+    public SendInvoice(Long chatId, String title, String description, String payload, String currency, LabeledPrice... prices) {
+        super(chatId);
+        add("title", title).add("description", description).add("payload", payload)
+                .add("currency", currency).add("prices", prices);
+    }
+
+    /**
+     * Backward compatibility: API 7.4, parameter "provider_token" became optional
+     * @deprecated Use constrcutor without 'provider_token' and 'start_parameter' instead
+     */
+    @Deprecated 
     public SendInvoice(Long chatId, String title, String description, String payload, String providerToken,
                         String currency, LabeledPrice... prices) {
         super(chatId);
@@ -15,7 +27,12 @@ public class SendInvoice extends AbstractSendRequest<SendInvoice> {
                 .add("currency", currency).add("prices", prices);
     }
 
-    // Backward compatibility: API 5.2, parameter "start_parameter" became optional
+    
+    /**
+     * Backward compatibility: API 5.2, parameter "start_parameter" became optional
+     * @deprecated Use constrcutor without 'start_parameter' instead
+     */
+    @Deprecated 
     public SendInvoice(Long chatId, String title, String description, String payload, String providerToken,
                        String startParameter, String currency, LabeledPrice... prices) {
         this(chatId, title, description, payload, providerToken, currency, prices);
@@ -64,6 +81,10 @@ public class SendInvoice extends AbstractSendRequest<SendInvoice> {
 
     public SendInvoice startParameter(String startParameter) {
         return add("start_parameter", startParameter);
+    }
+
+    public SendInvoice providerToken(String providerToken) {
+        return add("provider_token", providerToken);
     }
 
     /**

--- a/library/src/main/java/com/pengrad/telegrambot/request/SendPhoto.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SendPhoto.java
@@ -39,6 +39,10 @@ public class SendPhoto extends AbstractMultipartRequest<SendPhoto> {
         return add("has_spoiler", has_spoiler);
     }
 
+    public SendPhoto showCaptionAboveMedia(Boolean showCaptionAboveMedia) {
+        return add("show_caption_above_media", showCaptionAboveMedia);
+    }
+
     @Override
     protected String getFileParamName() {
         return "photo";

--- a/library/src/main/java/com/pengrad/telegrambot/request/SendPoll.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SendPoll.java
@@ -2,6 +2,7 @@ package com.pengrad.telegrambot.request;
 
 import com.pengrad.telegrambot.model.MessageEntity;
 import com.pengrad.telegrambot.model.Poll;
+import com.pengrad.telegrambot.model.request.InputPollOption;
 import com.pengrad.telegrambot.model.request.ParseMode;
 
 /**
@@ -10,6 +11,16 @@ import com.pengrad.telegrambot.model.request.ParseMode;
  */
 public class SendPoll extends AbstractSendRequest<SendPoll> {
 
+    public SendPoll(Object chatId, String question, InputPollOption... options) {
+        super(chatId);
+        add("question", question);
+        add("options", options);
+    }
+    
+    /**
+     * @deprecated Use constructor with InputPollOption parameters instead
+     */
+    @Deprecated 
     public SendPoll(Object chatId, String question, String... options) {
         super(chatId);
         add("question", question);

--- a/library/src/main/java/com/pengrad/telegrambot/request/SendPoll.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SendPoll.java
@@ -48,6 +48,14 @@ public class SendPoll extends AbstractSendRequest<SendPoll> {
         return add("explanation_entities", entities);
     }
 
+    public SendPoll questionParseMode(String questionParseMode) {
+        return add("question_parse_mode", questionParseMode);
+    }
+
+    public SendPoll questionEntities(MessageEntity... entities) {
+        return add("question_entities", entities);
+    }
+    
     public SendPoll openPeriod(int openPeriod) {
         return add("open_period", openPeriod);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/SendVideo.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SendVideo.java
@@ -79,6 +79,10 @@ public class SendVideo extends AbstractMultipartRequest<SendVideo> {
         return add("has_spoiler", has_spoiler);
     }
 
+    public SendVideo showCaptionAboveMedia(Boolean showCaptionAboveMedia) {
+        return add("show_caption_above_media", showCaptionAboveMedia);
+    }
+
     @Override
     protected String getFileParamName() {
         return "video";

--- a/library/src/main/java/com/pengrad/telegrambot/response/GetChatResponse.java
+++ b/library/src/main/java/com/pengrad/telegrambot/response/GetChatResponse.java
@@ -1,6 +1,6 @@
 package com.pengrad.telegrambot.response;
 
-import com.pengrad.telegrambot.model.Chat;
+import com.pengrad.telegrambot.model.ChatFullInfo;
 
 /**
  * Stas Parshin
@@ -8,9 +8,9 @@ import com.pengrad.telegrambot.model.Chat;
  */
 public class GetChatResponse extends BaseResponse {
 
-    private Chat result;
+    private ChatFullInfo result;
 
-    public Chat chat() {
+    public ChatFullInfo chat() {
         return result;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/utility/BotUtils.java
+++ b/library/src/main/java/com/pengrad/telegrambot/utility/BotUtils.java
@@ -4,10 +4,14 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.pengrad.telegrambot.model.Update;
+import com.pengrad.telegrambot.model.chatbackground.BackgroundFill;
+import com.pengrad.telegrambot.model.chatbackground.BackgroundType;
 import com.pengrad.telegrambot.model.chatboost.source.ChatBoostSource;
 import com.pengrad.telegrambot.model.message.MaybeInaccessibleMessage;
 import com.pengrad.telegrambot.model.message.origin.MessageOrigin;
 import com.pengrad.telegrambot.model.reaction.ReactionType;
+import com.pengrad.telegrambot.utility.gson.BackgroundFillAdapter;
+import com.pengrad.telegrambot.utility.gson.BackgroundTypeAdapter;
 import com.pengrad.telegrambot.utility.gson.ChatBoostSourceTypeAdapter;
 import com.pengrad.telegrambot.utility.gson.MaybeInaccessibleMessageTypeAdapter;
 import com.pengrad.telegrambot.utility.gson.MessageOriginTypeAdapter;
@@ -31,6 +35,8 @@ public class BotUtils {
             .registerTypeAdapter(MessageOrigin.class, new MessageOriginTypeAdapter())
             .registerTypeAdapter(ChatBoostSource.class, new ChatBoostSourceTypeAdapter())
             .registerTypeAdapter(MaybeInaccessibleMessage.class, new MaybeInaccessibleMessageTypeAdapter())
+            .registerTypeAdapter(BackgroundType.class, new BackgroundTypeAdapter())
+            .registerTypeAdapter(BackgroundFill.class, new BackgroundFillAdapter())
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
             .create();
 

--- a/library/src/main/java/com/pengrad/telegrambot/utility/gson/BackgroundFillAdapter.java
+++ b/library/src/main/java/com/pengrad/telegrambot/utility/gson/BackgroundFillAdapter.java
@@ -1,0 +1,28 @@
+package com.pengrad.telegrambot.utility.gson;
+
+import com.google.gson.*;
+import com.pengrad.telegrambot.model.chatbackground.BackgroundFill;
+import com.pengrad.telegrambot.model.chatbackground.BackgroundFillFreeformGradient;
+import com.pengrad.telegrambot.model.chatbackground.BackgroundFillGradient;
+import com.pengrad.telegrambot.model.chatbackground.BackgroundFillSolid;
+
+import java.lang.reflect.Type;
+
+public class BackgroundFillAdapter implements JsonDeserializer<BackgroundFill> {
+
+    @Override
+    public BackgroundFill deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException {
+        JsonObject object = element.getAsJsonObject();
+        String discriminator = object.getAsJsonPrimitive("type").getAsString();
+
+        if (BackgroundFillSolid.TYPE.equals(discriminator)) {
+            return context.deserialize(object, BackgroundFillSolid.class);
+        } else if (BackgroundFillGradient.TYPE.equals(discriminator)) {
+            return context.deserialize(object, BackgroundFillGradient.class);
+        } else if (BackgroundFillFreeformGradient.TYPE.equals(discriminator)) {
+            return context.deserialize(object, BackgroundFillFreeformGradient.class);
+        }
+
+        return context.deserialize(object, BackgroundFill.class);
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/utility/gson/BackgroundTypeAdapter.java
+++ b/library/src/main/java/com/pengrad/telegrambot/utility/gson/BackgroundTypeAdapter.java
@@ -1,0 +1,31 @@
+package com.pengrad.telegrambot.utility.gson;
+
+import com.google.gson.*;
+import com.pengrad.telegrambot.model.chatbackground.BackgroundType;
+import com.pengrad.telegrambot.model.chatbackground.BackgroundTypeChatTheme;
+import com.pengrad.telegrambot.model.chatbackground.BackgroundTypeFill;
+import com.pengrad.telegrambot.model.chatbackground.BackgroundTypePattern;
+import com.pengrad.telegrambot.model.chatbackground.BackgroundTypeWallpaper;
+
+import java.lang.reflect.Type;
+
+public class BackgroundTypeAdapter implements JsonDeserializer<BackgroundType> {
+
+    @Override
+    public BackgroundType deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException {
+        JsonObject object = element.getAsJsonObject();
+        String discriminator = object.getAsJsonPrimitive("type").getAsString();
+
+        if (BackgroundTypeFill.TYPE.equals(discriminator)) {
+            return context.deserialize(object, BackgroundTypeFill.class);
+        } else if (BackgroundTypeWallpaper.TYPE.equals(discriminator)) {
+            return context.deserialize(object, BackgroundTypeWallpaper.class);
+        } else if (BackgroundTypePattern.TYPE.equals(discriminator)) {
+            return context.deserialize(object, BackgroundTypePattern.class);
+        } else if (BackgroundTypeChatTheme.TYPE.equals(discriminator)) {
+            return context.deserialize(object, BackgroundTypeChatTheme.class);
+        }
+
+        return context.deserialize(object, BackgroundType.class);
+    }
+}

--- a/library/src/test/java/com/pengrad/telegrambot/TelegramBotTest.java
+++ b/library/src/test/java/com/pengrad/telegrambot/TelegramBotTest.java
@@ -466,7 +466,7 @@ public class TelegramBotTest {
 
     @Test
     public void getChat() throws MalformedURLException, URISyntaxException {
-        Chat chat = bot.execute(new GetChat(groupId)).chat();
+        ChatFullInfo chat = bot.execute(new GetChat(groupId)).chat();
         ChatTest.checkChat(chat, true);
         assertEquals(Chat.Type.supergroup, chat.type());
         assertTrue(chat.title().contains("Test Bot Group"));
@@ -1296,7 +1296,7 @@ public class TelegramBotTest {
                     .useIndependentChatPermissions(false));
             assertTrue(response.isOk());
 
-            Chat chat = bot.execute(new GetChat(groupId)).chat();
+            ChatFullInfo chat = bot.execute(new GetChat(groupId)).chat();
             ChatPermissions permissions = chat.permissions();
             if (bool) {
                 assertTrue(permissions.canSendMessages());

--- a/library/src/test/java/com/pengrad/telegrambot/TelegramBotTest.java
+++ b/library/src/test/java/com/pengrad/telegrambot/TelegramBotTest.java
@@ -467,7 +467,7 @@ public class TelegramBotTest {
     @Test
     public void getChat() throws MalformedURLException, URISyntaxException {
         ChatFullInfo chat = bot.execute(new GetChat(groupId)).chat();
-        ChatTest.checkChat(chat, true);
+        ChatTest.checkFullInfoChat(chat, true);
         assertEquals(Chat.Type.supergroup, chat.type());
         assertTrue(chat.title().contains("Test Bot Group"));
         assertTrue(chat.description().contains("New desc"));

--- a/library/src/test/java/com/pengrad/telegrambot/checks/ChatTest.java
+++ b/library/src/test/java/com/pengrad/telegrambot/checks/ChatTest.java
@@ -1,5 +1,6 @@
 package com.pengrad.telegrambot.checks;
 
+import com.pengrad.telegrambot.model.Chat;
 import com.pengrad.telegrambot.model.ChatFullInfo;
 
 import static org.junit.Assert.assertNotNull;
@@ -10,14 +11,21 @@ import static org.junit.Assert.assertNotNull;
  */
 public class ChatTest {
 
-    public static void checkChat(ChatFullInfo chat) {
-        checkChat(chat, chat.photo() != null);
+    public static void checkFullInfoChat(ChatFullInfo chat) {
+        checkFullInfoChat(chat, chat.photo() != null);
     }
 
-    public static void checkChat(ChatFullInfo chat, boolean photo) {
+    public static void checkFullInfoChat(ChatFullInfo chat, boolean photo) {
         assertNotNull(chat.id());
         assertNotNull(chat.type());
         if (photo) ChatPhotoTest.check(chat.photo());
     }
+
+    
+    public static void checkChat(Chat chat) {
+        assertNotNull(chat.id());
+        assertNotNull(chat.type());
+    }
+    
 
 }

--- a/library/src/test/java/com/pengrad/telegrambot/checks/ChatTest.java
+++ b/library/src/test/java/com/pengrad/telegrambot/checks/ChatTest.java
@@ -1,6 +1,6 @@
 package com.pengrad.telegrambot.checks;
 
-import com.pengrad.telegrambot.model.Chat;
+import com.pengrad.telegrambot.model.ChatFullInfo;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -10,11 +10,11 @@ import static org.junit.Assert.assertNotNull;
  */
 public class ChatTest {
 
-    public static void checkChat(Chat chat) {
+    public static void checkChat(ChatFullInfo chat) {
         checkChat(chat, chat.photo() != null);
     }
 
-    public static void checkChat(Chat chat, boolean photo) {
+    public static void checkChat(ChatFullInfo chat, boolean photo) {
         assertNotNull(chat.id());
         assertNotNull(chat.type());
         if (photo) ChatPhotoTest.check(chat.photo());

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.pengrad</groupId>
   <artifactId>java-telegram-bot-api</artifactId>
-  <version>7.2.1</version>
+  <version>7.4.0</version>
   <name>JavaTelegramBotApi</name>
   <description>Java API for Telegram Bot API</description>
   <url>https://github.com/pengrad/java-telegram-bot-api/</url>


### PR DESCRIPTION
Need to update the BOT API from v7.2 to v7.4 (released today, [changelog](https://core.telegram.org/bots/api-changelog#may-28-2024)).


Here's the task to be done, please write a comment if you plan to help on some features.
Help is very welcome.

**BOT API v7.3:**

- [x] Added support for [InlineKeyboardMarkup](https://core.telegram.org/bots/api#inlinekeyboardmarkup) with url, login_url, and callback_game buttons for messages sent on behalf of a business account.
- [x] Added the field via_join_request to the class [ChatMemberUpdated](https://core.telegram.org/bots/api#chatmemberupdated).
- [x] Added support for live locations that can be edited indefinitely, allowing 0x7FFFFFFF to be used as live_period.
- [x] Added the parameter live_period to the method [editMessageLiveLocation](https://core.telegram.org/bots/api#editmessagelivelocation).
- [x] Added the field question_entities to the class [Poll](https://core.telegram.org/bots/api#poll).
- [x] Added the field text_entities to the class [PollOption](https://core.telegram.org/bots/api#polloption).
- [x] Added the parameters question_parse_mode and question_entities to the method [sendPoll](https://core.telegram.org/bots/api#sendpoll).
- [x] Added the class [InputPollOption](https://core.telegram.org/bots/api#inputpolloption) and changed the type of the parameter options in the method [sendPoll](https://core.telegram.org/bots/api#sendpoll) to Array of [InputPollOption](https://core.telegram.org/bots/api#inputpolloption).
- [x] Added the classes [ChatBackground](https://core.telegram.org/bots/api#chatbackground), [BackgroundType](https://core.telegram.org/bots/api#backgroundtype), [BackgroundFill](https://core.telegram.org/bots/api#backgroundfill) and the field chat_background_set of type [ChatBackground](https://core.telegram.org/bots/api#chatbackground) to the class [Message](https://core.telegram.org/bots/api#message), describing service messages about background changes.
- [x] Split out the class [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo) from the class [Chat](https://core.telegram.org/bots/api#chat) and changed the return type of the method [getChat](https://core.telegram.org/bots/api#getchat) to [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo).
- [x] Added the field max_reaction_count to the class [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo).


**BOT API v7.4:**

- [x] Added support for payments in [Telegram Stars](https://t.me/BotNews/90) by introducing the new currency “XTR”.
- [x] The parameter provider_token of the methods [sendInvoice](https://core.telegram.org/bots/api#sendinvoice) and [createInvoiceLink](https://core.telegram.org/bots/api#createinvoicelink) must be omitted for payments in [Telegram Stars](https://t.me/BotNews/90).
- [x] The field provider_token in the class [InputInvoiceMessageContent](https://core.telegram.org/bots/api#inputinvoicemessagecontent) must be omitted for payments in [Telegram Stars](https://t.me/BotNews/90).
- [x] Added the method [refundStarPayment](https://core.telegram.org/bots/api#refundstarpayment).
- [x] Added the field effect_id to the class [Message](https://core.telegram.org/bots/api#message).
- [x] Added the parameter message_effect_id to the methods [sendMessage](https://core.telegram.org/bots/api#sendmessage), [sendPhoto](https://core.telegram.org/bots/api#sendphoto), [sendVideo](https://core.telegram.org/bots/api#sendvideo), [sendAnimation](https://core.telegram.org/bots/api#sendanimation), [sendAudio](https://core.telegram.org/bots/api#sendaudio), [sendDocument](https://core.telegram.org/bots/api#senddocument), [sendSticker](https://core.telegram.org/bots/api#sendsticker), [sendVideoNote](https://core.telegram.org/bots/api#sendvideonote), [sendVoice](https://core.telegram.org/bots/api#sendvoice), [sendLocation](https://core.telegram.org/bots/api#sendlocation), [sendVenue](https://core.telegram.org/bots/api#sendvenue), [sendContact](https://core.telegram.org/bots/api#sendcontact), [sendPoll](https://core.telegram.org/bots/api#sendpoll), [sendDice](https://core.telegram.org/bots/api#senddice), [sendInvoice](https://core.telegram.org/bots/api#sendinvoice), [sendGame](https://core.telegram.org/bots/api#sendgame), and [sendMediaGroup](https://core.telegram.org/bots/api#sendmediagroup).
- [x] Added the field show_caption_above_media to the classes [Message](https://core.telegram.org/bots/api#message), [InputMediaAnimation](https://core.telegram.org/bots/api#inputmediaanimation), [InputMediaPhoto](https://core.telegram.org/bots/api#inputmediaphoto), [InputMediaVideo](https://core.telegram.org/bots/api#inputmediavideo), [InlineQueryResultGif](https://core.telegram.org/bots/api#inlinequeryresultgif), [InlineQueryResultMpeg4Gif](https://core.telegram.org/bots/api#inlinequeryresultmpeg4gif), [InlineQueryResultPhoto](https://core.telegram.org/bots/api#inlinequeryresultphoto), [InlineQueryResultVideo](https://core.telegram.org/bots/api#inlinequeryresultvideo), [InlineQueryResultCachedGif](https://core.telegram.org/bots/api#inlinequeryresultcachedgif), [InlineQueryResultCachedMpeg4Gif](https://core.telegram.org/bots/api#inlinequeryresultcachedmpeg4gif), [InlineQueryResultCachedPhoto](https://core.telegram.org/bots/api#inlinequeryresultcachedphoto), and [InlineQueryResultCachedVideo](https://core.telegram.org/bots/api#inlinequeryresultcachedvideo).
- [x] Added the parameter show_caption_above_media to the methods [sendAnimation](https://core.telegram.org/bots/api#sendanimation), [sendPhoto](https://core.telegram.org/bots/api#sendphoto), [sendVideo](https://core.telegram.org/bots/api#sendvideo), [copyMessage](https://core.telegram.org/bots/api#copymessage), and [editMessageCaption](https://core.telegram.org/bots/api#editmessagecaption).
- [x] Added support for “expandable_blockquote” entities in received messages.
- [x] Added support for “expandable_blockquote” entity parsing in “MarkdownV2” and “HTML” parse modes.
- [x] Allowed to explicitly specify “expandable_blockquote” entities in formatted texts.

Thanks everyone!