### PR TITLE
BusinessConnection: use Long for the "user_chat_id" fields

### DIFF
--- a/library/src/main/java/com/pengrad/telegrambot/model/business/BusinessConnection.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/business/BusinessConnection.java
@@ -8,7 +8,7 @@ public class BusinessConnection {
 
     private String id;
     private User user;
-    private Integer user_chat_id;
+    private Long user_chat_id;
     private Integer date;
     private Boolean can_reply;
     private Boolean is_enabled;
@@ -21,7 +21,7 @@ public class BusinessConnection {
         return user;
     }
 
-    public Integer userChatId() {
+    public Long userChatId() {
         return user_chat_id;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/request/GetUserChatBoosts.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/GetUserChatBoosts.java
@@ -4,7 +4,7 @@ import com.pengrad.telegrambot.response.UserChatBoostsResponse;
 
 public class GetUserChatBoosts extends BaseRequest<GetUserChatBoosts, UserChatBoostsResponse> {
 
-    public GetUserChatBoosts(Object chatId, Integer userId) {
+    public GetUserChatBoosts(Object chatId, Long userId) {
         super(UserChatBoostsResponse.class);
         add("chat_id", chatId).add("user_id", userId);
     }

--- a/library/src/test/java/com/pengrad/telegrambot/TelegramBotTest.java
+++ b/library/src/test/java/com/pengrad/telegrambot/TelegramBotTest.java
@@ -1220,7 +1220,7 @@ public class TelegramBotTest {
 
     @Test
     public void getUserChatBoosts() {
-        ChatBoost[] chatBoosts = bot.execute(new GetUserChatBoosts(channelId, chatId.intValue())).boosts();
+        ChatBoost[] chatBoosts = bot.execute(new GetUserChatBoosts(channelId, chatId.longValue())).boosts();
         assertEquals(chatBoosts.length, 0);
     }
 


### PR DESCRIPTION
Fixes #386 