### PR TITLE
BOT API v7.5

### DIFF
--- a/library/src/main/java/com/pengrad/telegrambot/model/ChatMember.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/ChatMember.java
@@ -92,6 +92,7 @@ public class ChatMember implements Serializable {
     /**
      * @deprecated Use canManageVideoChats() instead
      */
+    @Deprecated
     public Boolean canManageVoiceChats() {
         return canManageVideoChats();
     }

--- a/library/src/main/java/com/pengrad/telegrambot/model/business/BusinessConnection.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/business/BusinessConnection.java
@@ -8,7 +8,7 @@ public class BusinessConnection {
 
     private String id;
     private User user;
-    private Integer user_chat_id;
+    private Long user_chat_id;
     private Integer date;
     private Boolean can_reply;
     private Boolean is_enabled;
@@ -21,7 +21,7 @@ public class BusinessConnection {
         return user;
     }
 
-    public Integer userChatId() {
+    public Long userChatId() {
         return user_chat_id;
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/message/origin/MessageOrigin.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/message/origin/MessageOrigin.java
@@ -9,6 +9,10 @@ public class MessageOrigin implements Serializable  {
     protected String type;
     protected Integer date;
 
+    public MessageOrigin(String type) {
+        this.type = type;
+    }
+
     public String type() {
         return type;
     }

--- a/library/src/main/java/com/pengrad/telegrambot/model/message/origin/MessageOriginChannel.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/message/origin/MessageOriginChannel.java
@@ -13,6 +13,10 @@ public class MessageOriginChannel extends MessageOrigin {
 
     private String author_signature;
 
+    public MessageOriginChannel() {
+        super(MESSAGE_ORIGIN_TYPE);
+    }
+
     public Chat chat() {
         return chat;
     }

--- a/library/src/main/java/com/pengrad/telegrambot/model/message/origin/MessageOriginChat.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/message/origin/MessageOriginChat.java
@@ -11,6 +11,9 @@ public class MessageOriginChat extends MessageOrigin {
     private Chat sender_chat;
     private String author_signature;
 
+    public MessageOriginChat() {
+        super(MESSAGE_ORIGIN_TYPE);
+    }
     public Chat senderChat() {
         return sender_chat;
     }

--- a/library/src/main/java/com/pengrad/telegrambot/model/message/origin/MessageOriginHiddenUser.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/message/origin/MessageOriginHiddenUser.java
@@ -8,6 +8,10 @@ public class MessageOriginHiddenUser extends MessageOrigin {
 
     private String sender_user_name;
 
+    public MessageOriginHiddenUser() {
+        super(MESSAGE_ORIGIN_TYPE);
+    }
+
     public String senderUserName() {
         return sender_user_name;
     }

--- a/library/src/main/java/com/pengrad/telegrambot/model/message/origin/MessageOriginUser.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/message/origin/MessageOriginUser.java
@@ -10,6 +10,9 @@ public class MessageOriginUser extends MessageOrigin {
 
     private User sender_user;
 
+    public MessageOriginUser() {
+        super(MESSAGE_ORIGIN_TYPE);
+    }
     public User senderUser() {
         return sender_user;
     }

--- a/library/src/main/java/com/pengrad/telegrambot/model/request/InputInvoiceMessageContent.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/request/InputInvoiceMessageContent.java
@@ -47,6 +47,7 @@ public class InputInvoiceMessageContent extends InputMessageContent implements S
      * Backward compatibility: API 7.4, parameter "provider_token" became optional
      * @deprecated Use constrcutor without 'provider_token' instead
      */
+    @Deprecated
     public InputInvoiceMessageContent(String title, String description, String payload, String providerToken, String currency, LabeledPrice[] prices) {
         this.title = title;
         this.description = description;

--- a/library/src/main/java/com/pengrad/telegrambot/model/stars/StarTransaction.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/stars/StarTransaction.java
@@ -1,0 +1,70 @@
+package com.pengrad.telegrambot.model.stars;
+
+import com.pengrad.telegrambot.model.stars.partner.TransactionPartner;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class StarTransaction implements Serializable {
+
+    private final static long serialVersionUID = 0L;
+
+    private String id;
+    private Integer amount;
+    private Integer date;
+
+    private TransactionPartner source;
+
+    private TransactionPartner receiver;
+
+
+    public String id() {
+        return id;
+    }
+
+    public Integer amount() {
+        return amount;
+    }
+
+    public Integer date() {
+        return date;
+    }
+
+    public TransactionPartner source() {
+        return source;
+    }
+
+    public TransactionPartner receiver() {
+        return receiver;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        StarTransaction that = (StarTransaction) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(amount, that.amount) &&
+                Objects.equals(date, that.date) &&
+                Objects.equals(source, that.source) &&
+                Objects.equals(receiver, that.receiver);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, amount, date, source, receiver);
+    }
+
+    @Override
+    public String toString() {
+        return "StarTransaction{" +
+                "id='" + id + "'," +
+                "amount='" + amount + "'," +
+                "date='" + date + "'," +
+                "source='" + source + "'," +
+                "receiver='" + receiver + "'" +
+                '}';
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/stars/StarTransactions.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/stars/StarTransactions.java
@@ -1,0 +1,38 @@
+package com.pengrad.telegrambot.model.stars;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+
+public class StarTransactions implements Serializable {
+
+    private final static long serialVersionUID = 0L;
+
+    private StarTransaction[] transactions;
+
+    public StarTransaction[] transactions() {
+        return transactions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        StarTransactions that = (StarTransactions) o;
+        return Arrays.equals(transactions, that.transactions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(transactions);
+    }
+
+    @Override
+    public String toString() {
+        return "StarTransactions{" +
+                "transactions='" + Arrays.toString(transactions) + "'" +
+                '}';
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/stars/partner/TransactionPartner.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/stars/partner/TransactionPartner.java
@@ -1,0 +1,41 @@
+package com.pengrad.telegrambot.model.stars.partner;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public abstract class TransactionPartner implements Serializable {
+
+    private final static long serialVersionUID = 0L;
+
+    private String type;
+
+    public TransactionPartner(String type) {
+        this.type = type;
+    }
+
+    public String type() {
+        return type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TransactionPartner that = (TransactionPartner) o;
+        return Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type);
+    }
+
+    @Override
+    public String toString() {
+        return "TransactionPartner{" +
+                "type='" + type + "'" +
+                '}';
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/stars/partner/TransactionPartnerFragment.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/stars/partner/TransactionPartnerFragment.java
@@ -1,0 +1,43 @@
+package com.pengrad.telegrambot.model.stars.partner;
+
+import com.pengrad.telegrambot.model.stars.withdrawal.RevenueWithdrawalState;
+
+import java.util.Objects;
+
+public class TransactionPartnerFragment extends TransactionPartner {
+
+    public final static String TYPE = "fragment";
+
+    private RevenueWithdrawalState withdrawal_state;
+
+    public TransactionPartnerFragment() {
+        super(TYPE);
+    }
+
+    public RevenueWithdrawalState withdrawalState() {
+        return withdrawal_state;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TransactionPartnerFragment that = (TransactionPartnerFragment) o;
+        return Objects.equals(type(), that.type()) &&
+                Objects.equals(withdrawal_state, that.withdrawal_state);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type(), withdrawal_state);
+    }
+
+    @Override
+    public String toString() {
+        return "TransactionPartnerFragment{" +
+                "type='" + type() + "\'," +
+                ", withdrawal_state=" + withdrawal_state + "\'" +
+                '}';
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/stars/partner/TransactionPartnerOther.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/stars/partner/TransactionPartnerOther.java
@@ -1,0 +1,34 @@
+package com.pengrad.telegrambot.model.stars.partner;
+
+import java.util.Objects;
+
+public class TransactionPartnerOther extends TransactionPartner {
+
+    public final static String TYPE = "other";
+
+    public TransactionPartnerOther() {
+        super(TYPE);
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TransactionPartnerOther that = (TransactionPartnerOther) o;
+        return Objects.equals(type(), that.type());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type());
+    }
+
+    @Override
+    public String toString() {
+        return "TransactionPartnerOther{" +
+                "type='" + type() + "\'" +
+                '}';
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/stars/partner/TransactionPartnerTelegramAds.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/stars/partner/TransactionPartnerTelegramAds.java
@@ -1,0 +1,34 @@
+package com.pengrad.telegrambot.model.stars.partner;
+
+import java.util.Objects;
+
+public class TransactionPartnerTelegramAds extends TransactionPartner {
+
+    public final static String TYPE = "telegram_ads";
+
+    public TransactionPartnerTelegramAds() {
+        super(TYPE);
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TransactionPartnerTelegramAds that = (TransactionPartnerTelegramAds) o;
+        return Objects.equals(type(), that.type());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type());
+    }
+
+    @Override
+    public String toString() {
+        return "TransactionPartnerTelegramAds{" +
+                "type='" + type() + "\'" +
+                '}';
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/stars/partner/TransactionPartnerUser.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/stars/partner/TransactionPartnerUser.java
@@ -1,0 +1,52 @@
+package com.pengrad.telegrambot.model.stars.partner;
+
+import com.pengrad.telegrambot.model.User;
+import com.pengrad.telegrambot.model.chatbackground.BackgroundFillFreeformGradient;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class TransactionPartnerUser extends TransactionPartner {
+
+    public final static String TYPE = "user";
+
+    private User user;
+    private String invoice_payload;
+
+    public TransactionPartnerUser() {
+        super(TYPE);
+    }
+
+    public User user() {
+        return user;
+    }
+
+    public String invoicePayload() {
+        return invoice_payload;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TransactionPartnerUser that = (TransactionPartnerUser) o;
+        return Objects.equals(type(), that.type()) &&
+                Objects.equals(user, that.user) &&
+                Objects.equals(invoice_payload, that.invoice_payload);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type(), user, invoice_payload);
+    }
+
+    @Override
+    public String toString() {
+        return "TransactionPartnerUser{" +
+                "type='" + type() + "\'," +
+                ", user=" + user + "\'," +
+                ", invoice_payload=" + invoice_payload + "\'" +
+                '}';
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/stars/withdrawal/RevenueWithdrawalState.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/stars/withdrawal/RevenueWithdrawalState.java
@@ -1,0 +1,43 @@
+package com.pengrad.telegrambot.model.stars.withdrawal;
+
+import com.pengrad.telegrambot.model.chatbackground.BackgroundFill;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public abstract class RevenueWithdrawalState implements Serializable {
+
+    private final static long serialVersionUID = 0L;
+
+    private String type = "unknown";
+
+    protected RevenueWithdrawalState(String type) {
+        this.type = type;
+    }
+
+    public String type() {
+        return type;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RevenueWithdrawalState that = (RevenueWithdrawalState) o;
+        return Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type);
+    }
+
+    @Override
+    public String toString() {
+        return "RevenueWithdrawalState{" +
+                "type='" + type + '\'' +
+                '}';
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/stars/withdrawal/RevenueWithdrawalStateFailed.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/stars/withdrawal/RevenueWithdrawalStateFailed.java
@@ -1,0 +1,19 @@
+package com.pengrad.telegrambot.model.stars.withdrawal;
+
+public class RevenueWithdrawalStateFailed extends RevenueWithdrawalState {
+
+    public static final String TYPE = "failed";
+
+
+    public RevenueWithdrawalStateFailed() {
+        super(TYPE);
+    }
+
+    @Override
+    public String toString() {
+        return "RevenueWithdrawalStateFailed{" +
+                "type='" + type() + '\'' +
+                '}';
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/stars/withdrawal/RevenueWithdrawalStatePending.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/stars/withdrawal/RevenueWithdrawalStatePending.java
@@ -1,0 +1,19 @@
+package com.pengrad.telegrambot.model.stars.withdrawal;
+
+public class RevenueWithdrawalStatePending extends RevenueWithdrawalState {
+
+    public static final String TYPE = "pending";
+
+
+    public RevenueWithdrawalStatePending() {
+        super(TYPE);
+    }
+
+    @Override
+    public String toString() {
+        return "RevenueWithdrawalStatePending{" +
+                "type='" + type() + '\'' +
+                '}';
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/stars/withdrawal/RevenueWithdrawalStateSucceeded.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/stars/withdrawal/RevenueWithdrawalStateSucceeded.java
@@ -1,0 +1,48 @@
+package com.pengrad.telegrambot.model.stars.withdrawal;
+
+import java.util.Objects;
+
+public class RevenueWithdrawalStateSucceeded extends RevenueWithdrawalState {
+
+    public static final String TYPE = "succeeded";
+
+    private Integer date;
+    private String url;
+
+    public RevenueWithdrawalStateSucceeded() {
+        super(TYPE);
+    }
+
+    public Integer date() {
+        return date;
+    }
+
+    public String url() {
+        return url;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RevenueWithdrawalStateSucceeded that = (RevenueWithdrawalStateSucceeded) o;
+        return Objects.equals(type(), that.type()) &&
+                Objects.equals(date, that.date) &&
+                Objects.equals(url, that.url);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type(), date, url);
+    }
+
+    @Override
+    public String toString() {
+        return "RevenueWithdrawalStateSucceeded{" +
+                "type='" + type() + "\'," +
+                "date='" + date + "\'," +
+                "url='" + url + "\'" +
+                '}';
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/CreateInvoiceLink.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/CreateInvoiceLink.java
@@ -20,6 +20,7 @@ public class CreateInvoiceLink extends BaseRequest<CreateInvoiceLink, StringResp
      * Backward compatibility: API 7.4, parameter "provider_token" became optional
      * @deprecated Use constrcutor without 'provider_token' instead
      */
+    @Deprecated
     public CreateInvoiceLink(String title, String description, String payload, String providerToken,
                              String currency, LabeledPrice... prices) {
         super(StringResponse.class);

--- a/library/src/main/java/com/pengrad/telegrambot/request/EditMessageCaption.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/EditMessageCaption.java
@@ -41,5 +41,8 @@ public class EditMessageCaption extends BaseRequest<EditMessageCaption, BaseResp
     public EditMessageCaption showCaptionAboveMedia(Boolean showCaptionAboveMedia) {
         return add("show_caption_above_media", showCaptionAboveMedia);
     }
+    public EditMessageCaption businessConnectionId(String businessConnectionId) {
+        return add("business_connection_id", businessConnectionId);
+    }
 
 }

--- a/library/src/main/java/com/pengrad/telegrambot/request/EditMessageLiveLocation.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/EditMessageLiveLocation.java
@@ -40,5 +40,8 @@ public class EditMessageLiveLocation extends BaseRequest<EditMessageLiveLocation
         return add("live_period", livePeriod);
     }
 
+    public EditMessageLiveLocation businessConnectionId(String businessConnectionId) {
+        return add("business_connection_id", businessConnectionId);
+    }
 
 }

--- a/library/src/main/java/com/pengrad/telegrambot/request/EditMessageMedia.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/EditMessageMedia.java
@@ -46,6 +46,10 @@ public class EditMessageMedia extends BaseRequest<EditMessageMedia, BaseResponse
         return add("reply_markup", replyMarkup);
     }
 
+    public EditMessageMedia businessConnectionId(String businessConnectionId) {
+        return add("business_connection_id", businessConnectionId);
+    }
+
     @Override
     public boolean isMultipart() {
         return isMultipart;

--- a/library/src/main/java/com/pengrad/telegrambot/request/EditMessageReplyMarkup.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/EditMessageReplyMarkup.java
@@ -24,4 +24,8 @@ public class EditMessageReplyMarkup extends BaseRequest<EditMessageReplyMarkup, 
         return add("reply_markup", replyMarkup);
     }
 
+    public EditMessageReplyMarkup businessConnectionId(String businessConnectionId) {
+        return add("business_connection_id", businessConnectionId);
+    }
+
 }

--- a/library/src/main/java/com/pengrad/telegrambot/request/EditMessageText.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/EditMessageText.java
@@ -46,4 +46,8 @@ public class EditMessageText extends BaseRequest<EditMessageText, BaseResponse> 
         return add("reply_markup", replyMarkup);
     }
 
+    public EditMessageText businessConnectionId(String businessConnectionId) {
+        return add("business_connection_id", businessConnectionId);
+    }
+
 }

--- a/library/src/main/java/com/pengrad/telegrambot/request/GetStarTransactions.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/GetStarTransactions.java
@@ -1,0 +1,25 @@
+package com.pengrad.telegrambot.request;
+
+import com.pengrad.telegrambot.response.GetStarTransactionsResponse;
+
+/**
+ * Stas Parshin
+ * 28 May 2016
+ */
+public class GetStarTransactions extends BaseRequest<GetStarTransactions, GetStarTransactionsResponse> {
+
+    public GetStarTransactions() {
+        super(GetStarTransactionsResponse.class);
+    }
+
+    public GetStarTransactions offset(Integer offset) {
+        add("offset", offset);
+        return this;
+    }
+
+    public GetStarTransactions limit(Integer limit) {
+        add("limit", limit);
+        return this;
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/GetUserChatBoosts.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/GetUserChatBoosts.java
@@ -4,7 +4,7 @@ import com.pengrad.telegrambot.response.UserChatBoostsResponse;
 
 public class GetUserChatBoosts extends BaseRequest<GetUserChatBoosts, UserChatBoostsResponse> {
 
-    public GetUserChatBoosts(Object chatId, Integer userId) {
+    public GetUserChatBoosts(Object chatId, Long userId) {
         super(UserChatBoostsResponse.class);
         add("chat_id", chatId).add("user_id", userId);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/PromoteChatMember.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/PromoteChatMember.java
@@ -52,6 +52,7 @@ public class PromoteChatMember extends BaseRequest<PromoteChatMember, BaseRespon
     /**
      * @deprecated Use canManageVideoChats(boolean canManageVideoChats) instead
      */
+    @Deprecated
     public PromoteChatMember canManageVoiceChats(boolean canManageVoiceChats) {
         return add("can_manage_video_chats", canManageVoiceChats);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/StopMessageLiveLocation.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/StopMessageLiveLocation.java
@@ -23,4 +23,8 @@ public class StopMessageLiveLocation extends BaseRequest<StopMessageLiveLocation
     public StopMessageLiveLocation replyMarkup(InlineKeyboardMarkup replyMarkup) {
         return add("reply_markup", replyMarkup);
     }
+
+    public StopMessageLiveLocation businessConnectionId(String businessConnectionId) {
+        return add("business_connection_id", businessConnectionId);
+    }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/request/StopPoll.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/StopPoll.java
@@ -17,4 +17,8 @@ public class StopPoll extends BaseRequest<StopPoll, PollResponse> {
     public StopPoll replyMarkup(Keyboard replyMarkup) {
         return add("reply_markup", replyMarkup);
     }
+
+    public StopPoll businessConnectionId(String businessConnectionId) {
+        return add("business_connection_id", businessConnectionId);
+    }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/response/GetStarTransactionsResponse.java
+++ b/library/src/main/java/com/pengrad/telegrambot/response/GetStarTransactionsResponse.java
@@ -1,0 +1,21 @@
+package com.pengrad.telegrambot.response;
+
+import com.pengrad.telegrambot.model.stars.StarTransactions;
+
+import java.util.Objects;
+
+public class GetStarTransactionsResponse extends BaseResponse {
+
+    private StarTransactions result;
+
+    public StarTransactions result() {
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "GetStarTransactionsResponse{" +
+                "result=" + Objects.toString(result) +
+                '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/utility/BotUtils.java
+++ b/library/src/main/java/com/pengrad/telegrambot/utility/BotUtils.java
@@ -10,12 +10,9 @@ import com.pengrad.telegrambot.model.chatboost.source.ChatBoostSource;
 import com.pengrad.telegrambot.model.message.MaybeInaccessibleMessage;
 import com.pengrad.telegrambot.model.message.origin.MessageOrigin;
 import com.pengrad.telegrambot.model.reaction.ReactionType;
-import com.pengrad.telegrambot.utility.gson.BackgroundFillAdapter;
-import com.pengrad.telegrambot.utility.gson.BackgroundTypeAdapter;
-import com.pengrad.telegrambot.utility.gson.ChatBoostSourceTypeAdapter;
-import com.pengrad.telegrambot.utility.gson.MaybeInaccessibleMessageTypeAdapter;
-import com.pengrad.telegrambot.utility.gson.MessageOriginTypeAdapter;
-import com.pengrad.telegrambot.utility.gson.ReactionTypeAdapter;
+import com.pengrad.telegrambot.model.stars.partner.TransactionPartner;
+import com.pengrad.telegrambot.model.stars.withdrawal.RevenueWithdrawalState;
+import com.pengrad.telegrambot.utility.gson.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -37,6 +34,8 @@ public class BotUtils {
             .registerTypeAdapter(MaybeInaccessibleMessage.class, new MaybeInaccessibleMessageTypeAdapter())
             .registerTypeAdapter(BackgroundType.class, new BackgroundTypeAdapter())
             .registerTypeAdapter(BackgroundFill.class, new BackgroundFillAdapter())
+            .registerTypeAdapter(RevenueWithdrawalState.class, new RevenueWithdrawalStateTypeAdapter())
+            .registerTypeAdapter(TransactionPartner.class, new TransactionPartnerTypeAdapter())
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
             .create();
 

--- a/library/src/main/java/com/pengrad/telegrambot/utility/gson/RevenueWithdrawalStateTypeAdapter.java
+++ b/library/src/main/java/com/pengrad/telegrambot/utility/gson/RevenueWithdrawalStateTypeAdapter.java
@@ -1,0 +1,28 @@
+package com.pengrad.telegrambot.utility.gson;
+
+import com.google.gson.*;
+import com.pengrad.telegrambot.model.stars.withdrawal.RevenueWithdrawalState;
+import com.pengrad.telegrambot.model.stars.withdrawal.RevenueWithdrawalStateFailed;
+import com.pengrad.telegrambot.model.stars.withdrawal.RevenueWithdrawalStatePending;
+import com.pengrad.telegrambot.model.stars.withdrawal.RevenueWithdrawalStateSucceeded;
+
+import java.lang.reflect.Type;
+
+public class RevenueWithdrawalStateTypeAdapter implements JsonDeserializer<RevenueWithdrawalState> {
+
+    @Override
+    public RevenueWithdrawalState deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException {
+        JsonObject object = element.getAsJsonObject();
+        String discriminator = object.getAsJsonPrimitive("type").getAsString();
+
+        if (RevenueWithdrawalStatePending.TYPE.equals(discriminator)) {
+            return context.deserialize(object, RevenueWithdrawalStatePending.class);
+        } else if (RevenueWithdrawalStateSucceeded.TYPE.equals(discriminator)) {
+            return context.deserialize(object, RevenueWithdrawalStateSucceeded.class);
+        } else if (RevenueWithdrawalStateFailed.TYPE.equals(discriminator)) {
+            return context.deserialize(object, RevenueWithdrawalStateFailed.class);
+        }
+
+        return context.deserialize(object, RevenueWithdrawalState.class);
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/utility/gson/TransactionPartnerTypeAdapter.java
+++ b/library/src/main/java/com/pengrad/telegrambot/utility/gson/TransactionPartnerTypeAdapter.java
@@ -1,0 +1,31 @@
+package com.pengrad.telegrambot.utility.gson;
+
+import com.google.gson.*;
+import com.pengrad.telegrambot.model.stars.partner.*;
+import com.pengrad.telegrambot.model.stars.withdrawal.RevenueWithdrawalState;
+import com.pengrad.telegrambot.model.stars.withdrawal.RevenueWithdrawalStateFailed;
+import com.pengrad.telegrambot.model.stars.withdrawal.RevenueWithdrawalStatePending;
+import com.pengrad.telegrambot.model.stars.withdrawal.RevenueWithdrawalStateSucceeded;
+
+import java.lang.reflect.Type;
+
+public class TransactionPartnerTypeAdapter implements JsonDeserializer<TransactionPartner> {
+
+    @Override
+    public TransactionPartner deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException {
+        JsonObject object = element.getAsJsonObject();
+        String discriminator = object.getAsJsonPrimitive("type").getAsString();
+
+        if (TransactionPartnerUser.TYPE.equals(discriminator)) {
+            return context.deserialize(object, TransactionPartnerUser.class);
+        } else if (TransactionPartnerFragment.TYPE.equals(discriminator)) {
+            return context.deserialize(object, TransactionPartnerFragment.class);
+        } else if (TransactionPartnerTelegramAds.TYPE.equals(discriminator)) {
+            return context.deserialize(object, TransactionPartnerTelegramAds.class);
+        } else if (TransactionPartnerOther.TYPE.equals(discriminator)) {
+            return context.deserialize(object, TransactionPartnerOther.class);
+        }
+
+        return context.deserialize(object, TransactionPartner.class);
+    }
+}

--- a/library/src/test/java/com/pengrad/telegrambot/TelegramBotTest.java
+++ b/library/src/test/java/com/pengrad/telegrambot/TelegramBotTest.java
@@ -1220,7 +1220,7 @@ public class TelegramBotTest {
 
     @Test
     public void getUserChatBoosts() {
-        ChatBoost[] chatBoosts = bot.execute(new GetUserChatBoosts(channelId, chatId.intValue())).boosts();
+        ChatBoost[] chatBoosts = bot.execute(new GetUserChatBoosts(channelId, chatId.longValue())).boosts();
         assertEquals(chatBoosts.length, 0);
     }
 


### PR DESCRIPTION
Implement BOT API v7.5 changes:

- [x] Added the classes [StarTransactions](https://core.telegram.org/bots/api#startransactions), [StarTransaction](https://core.telegram.org/bots/api#startransaction), [TransactionPartner](https://core.telegram.org/bots/api#transactionpartner) and [RevenueWithdrawalState](https://core.telegram.org/bots/api#revenuewithdrawalstate), containing information about Telegram Star transactions involving the bot.

- [x] Added the method [getStarTransactions](https://core.telegram.org/bots/api#getstartransactions) that can be used to get the list of all Telegram Star transactions for the bot.

- [x] Added support for callback buttons in [InlineKeyboardMarkup](https://core.telegram.org/bots/api#inlinekeyboardmarkup) for messages sent on behalf of a business account.

- [x] Added support for callback queries originating from a message sent on behalf of a business account.

- [x] Added the parameter business_connection_id to the methods [editMessageText](https://core.telegram.org/bots/api#editmessagetext), [editMessageMedia](https://core.telegram.org/bots/api#editmessagemedia), [editMessageCaption](https://core.telegram.org/bots/api#editmessagecaption), [editMessageLiveLocation](https://core.telegram.org/bots/api#editmessagelivelocation), [stopMessageLiveLocation](https://core.telegram.org/bots/api#stopmessagelivelocation) and [editMessageReplyMarkup](https://core.telegram.org/bots/api#editmessagereplymarkup), allowing the bot to edit business messages.

- [x] Added the parameter business_connection_id to the method [stopPoll](https://core.telegram.org/bots/api#stoppoll), allowing the bot to stop polls it sent on behalf of a business account.