### PR TITLE
Missing @Deprecated keyword on disableWebPagePreview methods

### DIFF
--- a/library/src/main/java/com/pengrad/telegrambot/model/request/InputTextMessageContent.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/request/InputTextMessageContent.java
@@ -41,6 +41,7 @@ public class InputTextMessageContent extends InputMessageContent implements Seri
     /*
     @deprecated Use linkPreviewOptions instead
     */
+    @Deprecated
     public InputTextMessageContent disableWebPagePreview(Boolean disableWebPagePreview) {
         this.disable_web_page_preview = disableWebPagePreview;
         return this;

--- a/library/src/main/java/com/pengrad/telegrambot/model/request/KeyboardButton.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/request/KeyboardButton.java
@@ -40,7 +40,7 @@ public class KeyboardButton implements Serializable {
     }
 
     /**
-     * @deprecated Use reqyestUsers instead
+     * @deprecated Use requestUsers instead
      */
     @Deprecated
     public KeyboardButton requestUser(KeyboardButtonRequestUser user) {

--- a/library/src/main/java/com/pengrad/telegrambot/request/EditMessageText.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/EditMessageText.java
@@ -38,6 +38,7 @@ public class EditMessageText extends BaseRequest<EditMessageText, BaseResponse> 
     /*
     @deprecated Use linkPreviewOptions instead
     */
+    @Deprecated
     public EditMessageText disableWebPagePreview(boolean disableWebPagePreview) {
         return add("disable_web_page_preview", disableWebPagePreview);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/request/SendMessage.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SendMessage.java
@@ -30,6 +30,7 @@ public class SendMessage extends AbstractSendRequest<SendMessage> {
     /*
     @deprecated Use linkPreviewOptions instead
     */
+    @Deprecated
     public SendMessage disableWebPagePreview(boolean disableWebPagePreview) {
         return add("disable_web_page_preview", disableWebPagePreview);
     }


### PR DESCRIPTION
`linkPreviewOptions` must be used instead to specify options in relation of link previews