### PR TITLE
BOT API v7.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/pengrad/java-telegram-bot-api/branch/master/graph/badge.svg)](https://codecov.io/gh/pengrad/java-telegram-bot-api)
 
 Java library for interacting with [Telegram Bot API](https://core.telegram.org/bots/api)
-- Full support of all Bot API 7.8 methods
+- Full support of all Bot API 7.9 methods
 - Telegram [Passport](https://core.telegram.org/passport) and Decryption API
 - Bot [Payments](https://core.telegram.org/bots/payments)
 - [Gaming Platform](https://telegram.org/blog/games)
@@ -13,14 +13,14 @@ Java library for interacting with [Telegram Bot API](https://core.telegram.org/b
 
 Gradle:
 ```groovy
-implementation 'com.github.pengrad:java-telegram-bot-api:7.8.0'
+implementation 'com.github.pengrad:java-telegram-bot-api:7.9.0'
 ```
 Maven:
 ```xml
 <dependency>
   <groupId>com.github.pengrad</groupId>
   <artifactId>java-telegram-bot-api</artifactId>
-  <version>7.8.0</version>
+  <version>7.9.0</version>
 </dependency>
 ```
 [JAR with all dependencies on release page](https://github.com/pengrad/java-telegram-bot-api/releases)

--- a/README_RU.md
+++ b/README_RU.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/pengrad/java-telegram-bot-api/branch/master/graph/badge.svg)](https://codecov.io/gh/pengrad/java-telegram-bot-api)
 
 Java библиотека, созданная для работы с [Telegram Bot API](https://core.telegram.org/bots/api)
-- Полная поддержка всех методов BOT API 7.8
+- Полная поддержка всех методов BOT API 7.9
 - Поддержка Telegram [паспорта](https://core.telegram.org/passport) и дешифровки (Decryption API);
 - Поддержка [платежей](https://core.telegram.org/bots/payments);
 - [Игровая платформа](https://telegram.org/blog/games).
@@ -13,14 +13,14 @@ Java библиотека, созданная для работы с [Telegram B
 
 Gradle:
 ```groovy
-implementation 'com.github.pengrad:java-telegram-bot-api:7.8.0'
+implementation 'com.github.pengrad:java-telegram-bot-api:7.9.0'
 ```
 Maven:
 ```xml
 <dependency>
   <groupId>com.github.pengrad</groupId>
   <artifactId>java-telegram-bot-api</artifactId>
-  <version>7.8.0</version>
+  <version>7.9.0</version>
 </dependency>
 ```
 Также JAR со всеми зависимостями можно найти [в релизах](https://github.com/pengrad/java-telegram-bot-api/releases).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.github.pengrad
-VERSION_NAME=7.8.0
+VERSION_NAME=7.9.0
 
 POM_DESCRIPTION=Java API for Telegram Bot API
 POM_URL=https://github.com/pengrad/java-telegram-bot-api/

--- a/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundFillFreeformGradient.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundFillFreeformGradient.java
@@ -2,7 +2,7 @@ package com.pengrad.telegrambot.model.chatbackground;
 
 import java.util.Arrays;
 
-public class BackgroundFillFreeformGradient extends BackgroundType {
+public class BackgroundFillFreeformGradient extends BackgroundFill {
 
     public static final String TYPE = "freeform_gradient";
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundFillGradient.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundFillGradient.java
@@ -2,7 +2,7 @@ package com.pengrad.telegrambot.model.chatbackground;
 
 import java.util.Objects;
 
-public class BackgroundFillGradient extends BackgroundType {
+public class BackgroundFillGradient extends BackgroundFill {
 
     public static final String TYPE = "gradient";
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundFillSolid.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/chatbackground/BackgroundFillSolid.java
@@ -2,7 +2,7 @@ package com.pengrad.telegrambot.model.chatbackground;
 
 import java.util.Objects;
 
-public class BackgroundFillSolid extends BackgroundType {
+public class BackgroundFillSolid extends BackgroundFill {
 
     public static final String TYPE = "solid";
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionTypeCustomEmoji.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionTypeCustomEmoji.java
@@ -38,7 +38,7 @@ public class ReactionTypeCustomEmoji extends ReactionType {
     public String toString() {
         return "ReactionTypeCustomEmoji{" +
             "type='" + type() + '\'' +
-            "custom_emoji_id='" + custom_emoji_id + '\'' +
+            ",custom_emoji_id='" + custom_emoji_id + '\'' +
             '}';
     }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionTypeEmoji.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionTypeEmoji.java
@@ -38,7 +38,7 @@ public class ReactionTypeEmoji extends ReactionType {
     public String toString() {
         return "ReactionTypeEmoji{" +
             "type='" + type() + '\'' +
-            "emoji='" + emoji + '\'' +
+            ",emoji='" + emoji + '\'' +
             '}';
     }
 }

--- a/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionTypePaid.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionTypePaid.java
@@ -1,0 +1,27 @@
+package com.pengrad.telegrambot.model.reaction;
+
+import java.util.Objects;
+
+public class ReactionTypePaid extends ReactionType {
+
+    public static final String EMOJI_TYPE = "paid";
+
+    public ReactionTypePaid() {
+        super(EMOJI_TYPE);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "ReactionTypePaid{" +
+            "type='" + type() + '\'' +
+            '}';
+    }
+}

--- a/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionTypePaid.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/reaction/ReactionTypePaid.java
@@ -4,10 +4,10 @@ import java.util.Objects;
 
 public class ReactionTypePaid extends ReactionType {
 
-    public static final String EMOJI_TYPE = "paid";
+    public static final String PAID_TYPE = "paid";
 
     public ReactionTypePaid() {
-        super(EMOJI_TYPE);
+        super(PAID_TYPE);
     }
 
     @Override

--- a/library/src/main/java/com/pengrad/telegrambot/model/stars/partner/TransactionPartnerUser.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/stars/partner/TransactionPartnerUser.java
@@ -2,6 +2,7 @@ package com.pengrad.telegrambot.model.stars.partner;
 
 import com.pengrad.telegrambot.model.User;
 import com.pengrad.telegrambot.model.chatbackground.BackgroundFillFreeformGradient;
+import com.pengrad.telegrambot.model.paidmedia.PaidMedia;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -12,6 +13,7 @@ public class TransactionPartnerUser extends TransactionPartner {
 
     private User user;
     private String invoice_payload;
+    private PaidMedia[] paid_media;
 
     public TransactionPartnerUser() {
         super(TYPE);
@@ -25,6 +27,10 @@ public class TransactionPartnerUser extends TransactionPartner {
         return invoice_payload;
     }
 
+    public PaidMedia[] paidMedia() {
+        return paid_media;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -32,7 +38,8 @@ public class TransactionPartnerUser extends TransactionPartner {
         TransactionPartnerUser that = (TransactionPartnerUser) o;
         return Objects.equals(type(), that.type()) &&
                 Objects.equals(user, that.user) &&
-                Objects.equals(invoice_payload, that.invoice_payload);
+                Objects.equals(invoice_payload, that.invoice_payload) &&
+                Objects.equals(paid_media, that.paid_media);
     }
 
     @Override
@@ -45,7 +52,8 @@ public class TransactionPartnerUser extends TransactionPartner {
         return "TransactionPartnerUser{" +
                 "type='" + type() + "\'," +
                 ", user=" + user + "\'," +
-                ", invoice_payload=" + invoice_payload + "\'" +
+                ", invoice_payload=" + invoice_payload + "\'," +
+                ", paid_media=" + paid_media + "\'" +
                 '}';
     }
 

--- a/library/src/main/java/com/pengrad/telegrambot/model/stars/partner/TransactionPartnerUser.java
+++ b/library/src/main/java/com/pengrad/telegrambot/model/stars/partner/TransactionPartnerUser.java
@@ -35,16 +35,14 @@ public class TransactionPartnerUser extends TransactionPartner {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
         TransactionPartnerUser that = (TransactionPartnerUser) o;
-        return Objects.equals(type(), that.type()) &&
-                Objects.equals(user, that.user) &&
-                Objects.equals(invoice_payload, that.invoice_payload) &&
-                Objects.equals(paid_media, that.paid_media);
+        return Objects.equals(user, that.user) && Objects.equals(invoice_payload, that.invoice_payload) && Objects.deepEquals(paid_media, that.paid_media);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type(), user, invoice_payload);
+        return Objects.hash(super.hashCode(), user, invoice_payload, Arrays.hashCode(paid_media));
     }
 
     @Override

--- a/library/src/main/java/com/pengrad/telegrambot/request/CreateChatSubscriptionInviteLink.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/CreateChatSubscriptionInviteLink.java
@@ -1,0 +1,34 @@
+package com.pengrad.telegrambot.request;
+
+import com.pengrad.telegrambot.response.ChatInviteLinkResponse;
+
+/**
+ * Stas Parshin
+ * 10 March 2021
+ */
+public class CreateChatSubscriptionInviteLink extends BaseRequest<CreateChatSubscriptionInviteLink, ChatInviteLinkResponse> {
+
+    /**
+     * Create a subscription invite link for a channel chat.
+     *
+     * @param chatId Unique identifier for the target channel chat or username of the target channel (in the format @channelusername)
+     * @param subscriptionPeriod The number of seconds the subscription will be active for before the next payment. Currently, it must always be 2592000 (30 days).
+     * @param subscriptionPrice The amount of Telegram Stars a user must pay initially and after each subsequent subscription period to be a member of the chat; 1-2500
+     */
+    public CreateChatSubscriptionInviteLink(Object chatId, Integer subscriptionPeriod, Integer subscriptionPrice) {
+        super(ChatInviteLinkResponse.class);
+        add("chat_id", chatId);
+        add("subscription_period", subscriptionPeriod);
+        add("subscription_price", subscriptionPrice);
+    }
+
+    /**
+     * 
+     * @param name Invite link name; 0-32 characters
+     */
+    public CreateChatSubscriptionInviteLink name(String name) {
+        return add("name", name);
+    }
+
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/EditChatSubscriptionInviteLink.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/EditChatSubscriptionInviteLink.java
@@ -1,0 +1,31 @@
+package com.pengrad.telegrambot.request;
+
+import com.pengrad.telegrambot.response.ChatInviteLinkResponse;
+
+/**
+ * Stas Parshin
+ * 10 March 2021
+ */
+public class EditChatSubscriptionInviteLink extends BaseRequest<EditChatSubscriptionInviteLink, ChatInviteLinkResponse> {
+
+    /**
+     * Edit a subscription invite link created by the bot
+     * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+     * @param inviteLink The invite link to edit
+     */
+    public EditChatSubscriptionInviteLink(Object chatId, String inviteLink) {
+        super(ChatInviteLinkResponse.class);
+        add("chat_id", chatId);
+        add("invite_link", inviteLink);
+    }
+
+    /**
+     * 
+     * @param name Invite link name; 0-32 characters
+     * @return
+     */
+    public EditChatSubscriptionInviteLink name(String name) {
+        return add("name", name);
+    }
+
+}

--- a/library/src/main/java/com/pengrad/telegrambot/request/SendPaidMedia.java
+++ b/library/src/main/java/com/pengrad/telegrambot/request/SendPaidMedia.java
@@ -44,6 +44,10 @@ public class SendPaidMedia extends BaseRequest<SendPaidMedia, SendResponse> {
         return add("reply_parameters", replyParameters);
     }
 
+    public SendPaidMedia businessConnectionId(String businessConnectionId) {
+        return add("business_connection_id", businessConnectionId);
+    }
+
     public SendPaidMedia replyMarkup(InlineKeyboardMarkup replyMarkup) {
         return add("reply_markup", replyMarkup);
     }

--- a/library/src/main/java/com/pengrad/telegrambot/utility/gson/ReactionTypeAdapter.java
+++ b/library/src/main/java/com/pengrad/telegrambot/utility/gson/ReactionTypeAdapter.java
@@ -4,6 +4,7 @@ import com.google.gson.*;
 import com.pengrad.telegrambot.model.reaction.ReactionType;
 import com.pengrad.telegrambot.model.reaction.ReactionTypeCustomEmoji;
 import com.pengrad.telegrambot.model.reaction.ReactionTypeEmoji;
+import com.pengrad.telegrambot.model.reaction.ReactionTypePaid;
 
 import java.lang.reflect.Type;
 
@@ -18,6 +19,8 @@ public class ReactionTypeAdapter implements JsonDeserializer<ReactionType> {
         if (ReactionTypeEmoji.EMOJI_TYPE.equals(discriminator)) {
             return context.deserialize(object, ReactionTypeEmoji.class);
         } else if (ReactionTypeCustomEmoji.CUSTOM_EMOJI_TYPE.equals(discriminator)) {
+            return context.deserialize(object, ReactionTypeCustomEmoji.class);
+        } else if (ReactionTypePaid.PAID_TYPE.equals(discriminator)) {
             return context.deserialize(object, ReactionTypeCustomEmoji.class);
         }
 

--- a/library/src/main/java/com/pengrad/telegrambot/utility/gson/ReactionTypeAdapter.java
+++ b/library/src/main/java/com/pengrad/telegrambot/utility/gson/ReactionTypeAdapter.java
@@ -21,7 +21,7 @@ public class ReactionTypeAdapter implements JsonDeserializer<ReactionType> {
         } else if (ReactionTypeCustomEmoji.CUSTOM_EMOJI_TYPE.equals(discriminator)) {
             return context.deserialize(object, ReactionTypeCustomEmoji.class);
         } else if (ReactionTypePaid.PAID_TYPE.equals(discriminator)) {
-            return context.deserialize(object, ReactionTypeCustomEmoji.class);
+            return context.deserialize(object, ReactionTypePaid.class);
         }
 
         return new ReactionType(discriminator);

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.pengrad</groupId>
   <artifactId>java-telegram-bot-api</artifactId>
-  <version>7.8.0</version>
+  <version>7.9.0</version>
   <name>JavaTelegramBotApi</name>
   <description>Java API for Telegram Bot API</description>
   <url>https://github.com/pengrad/java-telegram-bot-api/</url>


### PR DESCRIPTION
Hello,

this PR updates the library to v7.9 ([changelog](https://core.telegram.org/bots/api#august-14-2024)).


**Note:**
There is this change in the API update:
- Added the field until_date to the class [ChatMemberMember](https://core.telegram.org/bots/api#chatmembermember) for members with an active subscription

But the class `ChatMember` on the library already has the `until_date` field as it was implemented in a slightly different way that the one we used lately for other classes (like `ReactionType`, `ChatBoostSource` etc.) where we have used JSON Adapters to cast to the specific object. 

Maybe we should consider align the implementation of the `ChatMember` class (@anfanik what do you think?)

Thanks