### PR TITLE
Field "topicId" in DirectMessagesTopic updated to type Long

### DIFF
--- a/library/src/main/java/com/pengrad/telegrambot/model/DirectMessagesTopic.kt
+++ b/library/src/main/java/com/pengrad/telegrambot/model/DirectMessagesTopic.kt
@@ -2,7 +2,7 @@ package com.pengrad.telegrambot.model
 
 @Suppress("unused")
 data class DirectMessagesTopic (
-    @get:JvmName("topicId") val topicId: Int,
+    @get:JvmName("topicId") val topicId: Long,
     @get:JvmName("user") val user: User?
 ) {
 }

--- a/library/src/main/java/com/pengrad/telegrambot/request/AbstractSendRequest.kt
+++ b/library/src/main/java/com/pengrad/telegrambot/request/AbstractSendRequest.kt
@@ -16,7 +16,7 @@ abstract class AbstractSendRequest<REQ : AbstractSendRequest<REQ>>(
 
     var businessConnectionId: String? by optionalRequestParameter()
     var messageThreadId: Int? by optionalRequestParameter()
-    var directMessagesTopicId: Int? by optionalRequestParameter()
+    var directMessagesTopicId: Long? by optionalRequestParameter()
     var disableNotification: Boolean? by optionalRequestParameter()
     var protectContent: Boolean? by optionalRequestParameter()
     var allowPaidBroadcast: Boolean? by optionalRequestParameter()
@@ -29,7 +29,7 @@ abstract class AbstractSendRequest<REQ : AbstractSendRequest<REQ>>(
 
     fun messageThreadId(messageThreadId: Int) = applySelf { this.messageThreadId = messageThreadId }
 
-    fun directMessagesTopicId(directMessagesTopicId: Int) = applySelf { this.directMessagesTopicId = directMessagesTopicId }
+    fun directMessagesTopicId(directMessagesTopicId: Long) = applySelf { this.directMessagesTopicId = directMessagesTopicId }
 
     fun disableNotification(disableNotification: Boolean) = applySelf { this.disableNotification = disableNotification }
 


### PR DESCRIPTION
The field `topic_id` on the new added class `DirectMessagesTopic` is of type `Long`. 

`java.io.IOException: com.google.gson.JsonSyntaxException: java.lang.NumberFormatException: Expected an int but was 5638634867 at line 9 column 288 path $.result[7].message.direct_messages_topic.topic_id`

In the documentation, the term Integer is also used for 64-bit fields, so it may be safer to convert all Integers to Long in our code, as they might use larger values without prior notice.